### PR TITLE
correct a mistake in promotion example

### DIFF
--- a/tour6-deploying-with-promotions_5bb91da12c7d3a04dd5b5d8f.md
+++ b/tour6-deploying-with-promotions_5bb91da12c7d3a04dd5b5d8f.md
@@ -94,7 +94,7 @@ promotions:
     pipeline_file: production-deploy.yml
     auto_promote_on:
       - result: passed
-        branches:
+        branch:
           - master
   - name: Staging deploy
     pipeline_file: staging-deploy.yml


### PR DESCRIPTION
I believe this example is mistaken here.

This usage contradicts the other example shown at this page:
https://docs.semaphoreci.com/article/50-pipeline-yaml#example-of-auto_promote_on

where the adequate key is written as `branch` not `branches`.