### PR TITLE
Caching Big Repositories recipe

### DIFF
--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -34,14 +34,19 @@ remain intact during the lifetime of the Semaphore 2.0 project.
 
 ## An example project
 
-The example project of this section will use a single large file.
+The example project of this section will use multiple large files. Each one of
+the 10 files is around 100MB in size.
+
+Each file was generated using the following command:
+
+    dd if=/dev/random of=filename bs=1024 count=100000
 
 The `semaphore.yml` file for the example project will be the following:
 
 
 The Semaphore 2.0 environment variables that will be used are the following:
 
-* `SEMAPHORE_GIT_REPO_NAME`:
+* `SEMAPHORE_PROJECT_NAME`:
 * `SEMAPHORE_GIT_SHA`:
 
 ## Evaluating the results

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -1,35 +1,24 @@
 
 * [Overview](#overview)
-* [The scenario](#the-scenario)
 * [The logic behind the recipe](#the-logic-behind-the-recipe)
 * [An example project](#an-example-project)
 * [See Also](#see-also)
 
 ## Overview
 
-The purpose of this document is to provide a recipe for caching big
-repositories in order to save time.
-
-## The scenario
-
 Imagine that you have one or multiple large files on a GitHub repository and
-that you want to make the downloading of them as fast as possible.
-
-## The logic behind the recipe
-
-Using the Cache server provided by Semaphore 2.0 for getting the files of your
-GitHub repository is much faster than using the GitHub server machines for the
-same task because the Semaphore Cache server is on the same network as the
-Virtual Machines used for executing the jobs of a Semaphore pipeline.
-
-What the example project that follows will do is getting all the files of the
-GitHub repository in the first job using `checkout` and then storing them into
-the Semaphore 2.0 Cache server using `cache store`. The remaining jobs of the
-project will use these files from the Cache server using `cache restore`
-without calling `checkout` again.
+you want to make the downloading of them as fast as possible.
 
 Note that for this recipe to work, the files of the GitHub repository should
 remain intact through the lifetime of the Semaphore project.
+
+## The logic behind the recipe
+
+The example project that follows is getting all the files of the GitHub
+repository in the first job using `checkout` and then is storing them into the
+Semaphore 2.0 Cache server using `cache store`. The remaining jobs of the
+project will use these files from the Cache server using `cache restore`
+without calling `checkout` again.
 
 ## An example project
 
@@ -107,57 +96,6 @@ The `semaphore.yml` file for the example project will be the following:
 	          - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
 	          - ls -al "$SEMAPHORE_PROJECT_NAME"
 	          - du -k -s
-
-## Evaluating the results
-
-The same project was executed with and without using the Semaphore 2.0 Cache
-server.
-
-The output of the next `diff` command shows the differences between the
-pipeline files of the two versions:
-
-	$ diff .semaphore/semaphore.yml.cache .semaphore/semaphore.yml.nocache
-	16d15
-	<           - cache store "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA" $SEMAPHORE_PROJECT_NAME
-	23,24c22,23
-	<           - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
-	<           - ls -al "$SEMAPHORE_PROJECT_NAME"/FILES
-	---
-	>           - checkout
-	>           - ls -al
-	31c30,31
-	<           - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
-	---
-	>           - checkout
-	>           - cd ..
-	40,41c40,41
-	<           - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
-	<           - ls -al "$SEMAPHORE_PROJECT_NAME"/FILES
-	---
-	>           - checkout
-	>           - ls -al
-	45c45,46
-	<           - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
-	---
-	>           - checkout
-	>           - cd ..
-	53c54,55
-	<           - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
-	---
-	>           - checkout
-	>           - cd ..
-
-The total time it took the version that **uses** `cache` to finish the
-Semaphore 2.0 project was 332 seconds.
-
-The total time it took the version that uses `checkout` instead of `cache` to
-finish the Semaphore 2.0 project was 348 seconds.
-
-The improvement from using Semaphore 2.0 cache server was not that big due to
-the overhead introduced by the `cache store` command, which took 129 seconds
-to finish.
-
-Nevertheless, there was still a 16 seconds improvement!
 
 ## See Also
 

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -112,10 +112,10 @@ promotions can get executed even if one or more `jobs` of a pipeline fail.
 ## What to expect from this optimization
 
 * Using the Semaphore Cache server instead of GitHub servers will improve
-    stability.
+    the stability of the project.
 * Using the Semaphore Cache server instead of GitHub servers via `checkout`
-    will reduce the total number of seconds all jobs in a pipeline combined
-	spent, which will also reduce the price.
+    will reduce the execution time of the jobs of the pipeline, which will also
+	reduce the price.
 
 ## See Also
 

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -8,36 +8,35 @@
 ## Overview
 
 The purpose of this document is to provide a recipe for caching big
-repositories in order to reuse them faster.
+repositories in order to save time.
 
 ## The scenario
 
-Imagine that you have one or more large files on a GitHub repository and that
-you want to make the downloading of them as fast as possible.
+Imagine that you have one or multiple large files on a GitHub repository and
+that you want to make the downloading of them as fast as possible.
 
 ## The logic behind the recipe
 
 Using the Cache server provided by Semaphore 2.0 for getting the files of your
 GitHub repository is much faster than using the GitHub server machines for the
-same task because the Semaphore 2.0 Cache server in on the same network as the
-Virtual Machines used for executing the jobs of the Semaphore 2.0 pipeline.
-Therefore using the Semaphore 2.0 Cache server is faster than downloading files
-from the GitHub servers.
+same task because the Semaphore Cache server is on the same network as the
+Virtual Machines used for executing the jobs of a Semaphore pipeline.
 
 What the example project that follows will do is getting all the files of the
-GitHub repository using `checkout` in the first job and the storing them into
-the Semaphore 2.0 Cache server. The remaining jobs of the project will use
-these files from the Cache server without calling `checkout` again.
+GitHub repository in the first job using `checkout` and then storing them into
+the Semaphore 2.0 Cache server using `cache store`. The remaining jobs of the
+project will use these files from the Cache server using `cache restore`
+without calling `checkout` again.
 
 Note that for this recipe to work, the files of the GitHub repository should
-remain intact during the lifetime of the Semaphore 2.0 project.
+remain intact through the lifetime of the Semaphore project.
 
 ## An example project
 
-The example project of this section will use multiple large files. Each one of
-the 10 files is around 100MB in size.
+The example project of this section will use 10 large files. Each one of these
+10 files is around 100MB in size.
 
-Each file was generated using the following command:
+Each one file was generated using the following command:
 
     dd if=/dev/random of=filename bs=1024 count=100000
 
@@ -45,11 +44,11 @@ The Semaphore 2.0 environment variables that will be used are the following:
 
 * `SEMAPHORE_PROJECT_NAME`: This environment variable holds the name of the
     current Semaphore 2.0 project.
-* `SEMAPHORE_GIT_SHA`: This variable holds the current revision of the GitHub
-    code that the pipeline is using.
+* `SEMAPHORE_GIT_SHA`: This environment variable holds the current revision of
+    the GitHub code that the pipeline is using.
 
-The combination of `SEMAPHORE_PROJECT_NAME` and `SEMAPHORE_GIT_SHA` gets
-updated each time you make changes to the GitHub repository.
+Note that the combination of `SEMAPHORE_PROJECT_NAME` and `SEMAPHORE_GIT_SHA`
+gets updated each time you make changes to the GitHub repository.
 
 The `semaphore.yml` file for the example project will be the following:
 
@@ -114,10 +113,10 @@ The `semaphore.yml` file for the example project will be the following:
 The same project was executed with and without using the Semaphore 2.0 Cache
 server.
 
-The output of the `diff` command shows the differences between the two
-versions:
+The output of the next `diff` command shows the differences between the
+pipeline files of the two versions:
 
-	diff .semaphore/semaphore.yml.cache .semaphore/semaphore.yml.nocache
+	$ diff .semaphore/semaphore.yml.cache .semaphore/semaphore.yml.nocache
 	16d15
 	<           - cache store "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA" $SEMAPHORE_PROJECT_NAME
 	23,24c22,23
@@ -155,7 +154,8 @@ The total time it took the version that uses `checkout` instead of `cache` to
 finish the Semaphore 2.0 project was 348 seconds.
 
 The improvement from using Semaphore 2.0 cache server was not that big due to
-the overhead introduced by the `cache store` command, which was 129 seconds.
+the overhead introduced by the `cache store` command, which took 129 seconds
+to finish.
 
 Nevertheless, there was still a 16 seconds improvement!
 

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -6,11 +6,13 @@
 
 ## Overview
 
-Imagine that you have one or multiple large files on a GitHub repository and
-you want to make the downloading of them as fast as possible.
+This guide shows you how to cache a large Git repository and avoid cloning it
+from scratch in every block.
 
 Note that for this recipe to work, the files of the GitHub repository should
-remain intact through the lifetime of the Semaphore project.
+remain intact during the execution of the pipeline or you will end up having
+a different version of the files in the GitHub repository and in the Semaphore
+Cache server.
 
 ## The logic behind the recipe
 

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -46,7 +46,8 @@ The Semaphore 2.0 environment variables that will be used are the following:
 
 ## Evaluating the results
 
-The same project was executed with and without using
+The same project was executed with and without using the Semaphore 2.0 cache
+server.
 
 ## See Also
 

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -1,7 +1,42 @@
 
+* [Overview](#overview)
+* [The scenario](#the-scenario)
+* [The logic behind the recipe](#the-logic-behind-the-recipe)
+* [An example project](#an-example-project)
+* [See Also](#see-also)
+
 ## Overview
 
-##
+The purpose of this document is to provide a recipe for caching big
+repositories for speed.
+
+## The scenario
+
+Imagine that you have one or more huge files on a GitHub repository and that
+you want to make the downloading of them as fast as possible.
+
+## The logic behind the recipe
+
+Using the Cache server provided by Semaphore 2.0 is much faster than user the
+GitHub server machines because the Semaphore 2.0 Cache server in on the same
+network with the Virtual Machines used for executing the jobs of the Semaphore
+2.0 pipeline. Therefore using the Semaphore 2.0 Cache server is faster than
+downloading files from the GitHub servers.
+
+## An example project
+
+The `semaphore.yml` file for the example project will be the following:
+
+
+The Semaphore 2.0 environment variables that will be used are the following:
+
+* `SEMAPHORE_GIT_REPO_NAME`:
+* `SEMAPHORE_GIT_SHA`:
 
 
 ## See Also
+
+* [Installing sem](https://docs.semaphoreci.com/article/63-your-first-project)
+* [Pipeline YAML reference](https://docs.semaphoreci.com/article/50-pipeline-yaml)
+* [sem command line tool Reference](https://docs.semaphoreci.com/article/53-sem-reference)
+* [Toolbox reference page](https://docs.semaphoreci.com/article/54-toolbox-reference)

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -1,0 +1,7 @@
+
+## Overview
+
+##
+
+
+## See Also

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -8,22 +8,33 @@
 ## Overview
 
 The purpose of this document is to provide a recipe for caching big
-repositories for speed.
+repositories in order to reuse them faster.
 
 ## The scenario
 
-Imagine that you have one or more huge files on a GitHub repository and that
+Imagine that you have one or more large files on a GitHub repository and that
 you want to make the downloading of them as fast as possible.
 
 ## The logic behind the recipe
 
-Using the Cache server provided by Semaphore 2.0 is much faster than user the
-GitHub server machines because the Semaphore 2.0 Cache server in on the same
-network with the Virtual Machines used for executing the jobs of the Semaphore
-2.0 pipeline. Therefore using the Semaphore 2.0 Cache server is faster than
-downloading files from the GitHub servers.
+Using the Cache server provided by Semaphore 2.0 for getting the files of your
+GitHub repository is much faster than using the GitHub server machines for the
+same task because the Semaphore 2.0 Cache server in on the same network as the
+Virtual Machines used for executing the jobs of the Semaphore 2.0 pipeline.
+Therefore using the Semaphore 2.0 Cache server is faster than downloading files
+from the GitHub servers.
+
+What the example project that follows will do is getting all the files of the
+GitHub repository using `checkout` in the first job and the storing them into
+the Semaphore 2.0 Cache server. The remaining jobs of the project will use
+these files from the Cache server without calling `checkout` again.
+
+Note that for this recipe to work, the files of the GitHub repository should
+remain intact during the lifetime of the Semaphore 2.0 project.
 
 ## An example project
+
+The example project of this section will use a single large file.
 
 The `semaphore.yml` file for the example project will be the following:
 
@@ -33,6 +44,9 @@ The Semaphore 2.0 environment variables that will be used are the following:
 * `SEMAPHORE_GIT_REPO_NAME`:
 * `SEMAPHORE_GIT_SHA`:
 
+## Evaluating the results
+
+The same project was executed with and without using
 
 ## See Also
 

--- a/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
+++ b/caching-big-repositories_5bf03fb92c7d3a31944e139d.md
@@ -43,9 +43,13 @@ Each file was generated using the following command:
 
 The Semaphore 2.0 environment variables that will be used are the following:
 
-* `SEMAPHORE_PROJECT_NAME`:
-* `SEMAPHORE_GIT_SHA`:
+* `SEMAPHORE_PROJECT_NAME`: This environment variable holds the name of the
+    current Semaphore 2.0 project.
+* `SEMAPHORE_GIT_SHA`: This variable holds the current revision of the GitHub
+    code that the pipeline is using.
 
+The combination of `SEMAPHORE_PROJECT_NAME` and `SEMAPHORE_GIT_SHA` gets
+updated each time you make changes to the GitHub repository.
 
 The `semaphore.yml` file for the example project will be the following:
 
@@ -104,7 +108,6 @@ The `semaphore.yml` file for the example project will be the following:
 	          - cache restore "$SEMAPHORE_PROJECT_NAME-$SEMAPHORE_GIT_SHA"
 	          - ls -al "$SEMAPHORE_PROJECT_NAME"
 	          - du -k -s
-
 
 ## Evaluating the results
 


### PR DESCRIPTION
Using Semaphore 2.0 cache server instead of `checkout`.

Closes #123.