### PR TITLE
Correct caching example

### DIFF
--- a/language-ruby_5bb9e082042863158cc7236d.md
+++ b/language-ruby_5bb9e082042863158cc7236d.md
@@ -32,10 +32,10 @@ Here's an example:
 
 ## Dependency caching
 
-You can use Semaphores `cache` command to store and load a gem bundle.
-This requires setting the `BUNDLE_PATH` environment variable. In the following
-configuration example, we install dependencies and warm the cache in the first
-block, then use the cache in subsequent blocks.
+You can use Semaphores `cache` command to store and load a gem bundle
+and configuration. In the following configuration example, we install
+dependencies and warm the cache in the first block, then use the cache
+in subsequent blocks.
 
 <pre><code class="language-yaml">#.semaphore/semaphore.yml
 version: "v1.0"
@@ -52,19 +52,18 @@ blocks:
         - name: cache bundle
           commands:
             - checkout
-            - cache restore bundle-$(checksum Gemfile.lock)
+            - cache restore bundle-gems-$(checksum Gemfile.lock)
             - bundle install --deployment
-            - cache store bundle-$(checksum Gemfile.lock) vendor/bundle
+            - cache store bundle-gems-$(checksum Gemfile.lock) vendor/bundle
+            - cache store bundle-config-$(checksum Gemfile.lock) .bundle
 
   - name: Tests
     task:
       prologue:
         commands:
           - checkout
-          - cache restore bundle-$(checksum Gemfile.lock)
-      env_vars:
-        - name: BUNDLE_PATH
-          value: vendor/bundle
+          - cache store bundle-gems-$(checksum Gemfile.lock)
+          - cache store bundle-config-$(checksum Gemfile.lock)
       jobs:
         - name: Test all the things
           commands:


### PR DESCRIPTION
The .bundle directory must be cached and restored as well since that saves settings after bundle install --deployment.

Close: #130.

Refer to https://github.com/ahawkins/semaphore2-example-rails for a working implementation.