### PR TITLE
Fix a link to the toolbox repository

### DIFF
--- a/toolbox-reference_5b7bdc1d0428631d7a8a2fcc.md
+++ b/toolbox-reference_5b7bdc1d0428631d7a8a2fcc.md
@@ -17,6 +17,8 @@ This document explains the use of the command line tools found in the
 open source [semaphoreci/toolbox][toolbox-repo] repository and are
 preinstalled in all Semaphore 2.0 Virtual Machines (VM).
 
+[toolbox-repo]: https://github.com/semaphoreci/toolbox
+
 ## Essentials
 
 This section contains the most frequently used tools of the Semaphore 2.0


### PR DESCRIPTION
The link to the toolbox repository was missing its corresponding definition. As such, it wasn't being rendered.