### PR TITLE
Syntax highlighting demo, using code-prettify

### DIFF
--- a/syntax-highlighting-test.html
+++ b/syntax-highlighting-test.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Syntax highlighting test</title>
+    <script src="https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js"></script>
+  </head>
+  <body>
+    <h1>Syntax highlighting with google/code-prettify</h1>
+    <pre class="prettyprint language-yaml"># .semaphore/semaphore.yml
+blocks:
+  - name: "Test"
+    task:
+      prologue:
+        commands:
+          - git clone https://github.com/bats-core/bats-core.git
+          - cd bats
+          - sudo ./install.sh /usr/local
+      jobs:
+        - name: Tests
+          commands:
+            - bats addition.bats
+    </pre>
+  </body>
+</html>


### PR DESCRIPTION
I've looked into how we could add syntax highlighting to our code snippets. Help Scout [recommends](https://docs.helpscout.net/article/277-syntax-highlighting) using [google/code-prettify](https://github.com/google/code-prettify). It doesn't look that great in case of YAML imo:

![screen shot 2018-11-26 at 09 15 04](https://user-images.githubusercontent.com/8651/49001264-837b9600-f15c-11e8-9dc0-bd1ef0c341c6.png)

This PR adds a bare-bones HTML page which loads prettify on a sample snippet. We may keep it for reference or just not merge this.