### PR TITLE
Introduce Apple hardware

### DIFF
--- a/machine-types_5b24032b0428632c466af399.md
+++ b/machine-types_5b24032b0428632c466af399.md
@@ -108,16 +108,10 @@ types in pipelines see pipeline [agent documentation][1].
 		 4
 	</td>
 	<td>
-		 25
+		 50
 	</td>
 </tr>
 </tbody>
 </table>
-
-#####  Implementation of `a1` series of machine types:
-
-1.  Virtual CPU is implemented as a single hardware hyper-thread on a (?).
-2.  Memory is implemented as (?) RAM.
-3.  Disk is implemented as (?).
 
 [1]: https://docs.semaphoreci.com/article/50-pipeline-yaml#agent

--- a/machine-types_5b24032b0428632c466af399.md
+++ b/machine-types_5b24032b0428632c466af399.md
@@ -5,6 +5,8 @@ including the memory size, virtual CPU count, and disk.
 This guide describes the available machine types. For using machine
 types in pipelines see pipeline [agent documentation][1].
 
+### Linux machine types
+
 <table style="background-color: rgb(255, 255, 255);">
 <thead>
 <tr>
@@ -74,5 +76,48 @@ types in pipelines see pipeline [agent documentation][1].
     3.4GHz, Max Turbo 4.0GHz Intel® Core™ i7.
 2.  Memory is implemented as DDR4 RAM.
 3.  Disk is implemented as RAM drive backed by DDR4 RAM.
+
+### Apple machine types
+
+<table style="background-color: rgb(255, 255, 255);">
+<thead>
+<tr>
+	<td>
+		 Machine name
+	</td>
+	<td>
+		 Virtual CPUs <sup>1</sup>
+	</td>
+	<td>
+		 Memory (GB) <sup>2</sup>
+	</td>
+	<td>
+		 Disk (GB) <sup>3</sup>
+	</td>
+</tr>
+</thead>
+<tbody>
+<tr>
+	<td>
+		 a1-standard-2
+	</td>
+	<td>
+		 2
+	</td>
+	<td>
+		 4
+	</td>
+	<td>
+		 25
+	</td>
+</tr>
+</tbody>
+</table>
+
+#####  Implementation of `a1` series of machine types:
+
+1.  Virtual CPU is implemented as a single hardware hyper-thread on a (?).
+2.  Memory is implemented as (?) RAM.
+3.  Disk is implemented as (?).
 
 [1]: https://docs.semaphoreci.com/article/50-pipeline-yaml#agent


### PR DESCRIPTION
This PR is a preparation for the beta release of the MacOS build platform.

- What do you think of the separation between Linux & Apple machine types? This is technically not correct, there is no machine type called "linux"? An alternative would be to call them "Standard" & "Apple".
- Is it better like this, or should we keep them in the same table?

---

TODO: specify Apple hardware specs in the documentation (replace ? with real values)

