### PR TITLE
Multiple updates on languages and versions

### DIFF
--- a/language-elixir_5bdc647204286356f0a56048.md
+++ b/language-elixir_5bdc647204286356f0a56048.md
@@ -20,7 +20,7 @@ CI pipeline that you can use to get started quickly:
 
 Semaphore uses [kiex](https://github.com/taylor/kiex) to manage
 Elixir versions. Any version installable with kiex is supported on
-Semaphore. Version 1.7 is pre-installed. You may install new versions
+Semaphore. Version 1.7 and 1.8.1 is pre-installed. You may install new versions
 and change them with `sem-version`. Here's an example:
 
 <pre><code class="language-yaml">

--- a/language-elixir_5bdc647204286356f0a56048.md
+++ b/language-elixir_5bdc647204286356f0a56048.md
@@ -20,7 +20,7 @@ CI pipeline that you can use to get started quickly:
 
 Semaphore uses [kiex](https://github.com/taylor/kiex) to manage
 Elixir versions. Any version installable with kiex is supported on
-Semaphore. Version 1.7 and 1.8.1 is pre-installed. You may install new versions
+Semaphore. Version 1.7 and 1.8 is pre-installed. You may install new versions
 and change them with `sem-version`. Here's an example:
 
 <pre><code class="language-yaml">

--- a/ubuntu-1804-image_5b461f730428630abc0bf442.md
+++ b/ubuntu-1804-image_5b461f730428630abc0bf442.md
@@ -106,7 +106,7 @@ Erlang versions are installed and managed via [kerl](https://github.com/kerl/ker
 Elixir versions are installed with [kiex](https://github.com/taylor/kiex).
 
 - Erlang: 20.3, 21.0
-- Elixir: 1.7.3
+- Elixir: 1.7.3, 1.8.1
 
 Additional libraries:
 
@@ -119,7 +119,7 @@ Versions:
 
 - 1.10
 - 1.11
-- 1.12
+- 1.12.1
 
 ### Haskell
 
@@ -129,7 +129,7 @@ Versions:
 ### Java and JVM languages
 
 - Java: 8u201, 10.0.2, 11.0.2
-- Scala: 2.11.11, 2.12.6
+- Scala: 2.11.11, 2.12.7
 - Leiningen: 2.9.1 (Clojure)
 - sbt
 
@@ -199,6 +199,7 @@ Installed versions:
 - 2.5.0 to 2.5.3
 - 2.6.0
 - 2.6.1
+- 2.6.2
 - jruby-9.1.17.0
 
 ### Rust

--- a/ubuntu-1804-image_5b461f730428630abc0bf442.md
+++ b/ubuntu-1804-image_5b461f730428630abc0bf442.md
@@ -44,7 +44,7 @@ Following version control tools are pre-installed:
 
 - Firefox 60.1 
 - geckodriver 0.21.0
-- Google Chrome 72
+- Google Chrome 73
 - chrome_driver 2.46
 - xvfb (X Virtual Framebuffer)
 


### PR DESCRIPTION
+ elixir 1.8.1
scala 2.12.6 -> 2.12.7
Added ruby 2.6.2
Chrome 72-> 73
go 1.12.0->1.12.1, since ints only 1.12 specified no modifications here