### PR TITLE
Epilogue on_pass/on_fail commands

### DIFF
--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -725,7 +725,7 @@ The order of command execution is the following:
 - First, the `always` commands are executed
 - Then the `on_pass` or `on_fail` commands are executed
 
-### Example of epilogue
+Example of epilogue:
 
 ``` yaml
 version: v1.0
@@ -752,6 +752,45 @@ blocks:
           commands:
             - echo "This command runs if job has failed"
 ```
+
+Commands can be defined as a list directly in the YAML file, as in the above
+example, or via a `commands_file` property:
+
+``` yaml
+version: v1.0
+name: YAML file illustrating the epilogue property
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+ - name: Linux version
+   task:
+      jobs:
+        - name: Execute uname
+          commands:
+            - uname -a
+      epilogue:
+        always:
+          commands_file: file_with_epilogue_always_commands.sh
+        on_pass:
+          commands_file: file_with_epilogue_on_pass_commands.sh
+        on_fail:
+          commands_file: file_with_epilogue_on_fail_commands.sh
+```
+
+Where the content of the files is a list of commands, like in the following
+example:
+
+``` bash
+echo "hello from command file"
+echo "hello from $SEMAPHORE_GIT_BRANCH/$SEMAPHORE_GIT_SHA"
+```
+
+The location of the file is relative to the pipeline file. For example, if your
+pipeline file is located in `.semaphore/semaphore.yml`, the
+`file_with_epilogue_always_commands.sh` in the above example is assumed to live
+in `.semaphore/file_with_epilogue_always_commands.sh`.
 
 ## The secrets property
 

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -409,57 +409,63 @@ quotes.
 
 ### Example of task
 
-    version: v1.0
-    name: The name of the Semaphore 2.0 project
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-       task:
-          jobs:
-            - name: Check environment variables
-              commands:
-                - echo $SEMAPHORE_PIPELINE_ID
-                - echo $HOME
-                - echo $PI
-                - pwd
-          prologue:
-              commands:
-                - checkout
-          env_vars:
-               - name: PI
-                 value: "3.14159"
+``` yaml
+version: v1.0
+name: The name of the Semaphore 2.0 project
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+   task:
+      jobs:
+        - name: Check environment variables
+          commands:
+            - echo $SEMAPHORE_PIPELINE_ID
+            - echo $HOME
+            - echo $PI
+            - pwd
+
+      prologue:
+        commands:
+          - checkout
+
+      env_vars:
+        - name: PI
+          value: "3.14159"
+```
 
 *Caution*: The indentation level of `prologue`, `epilogue`, `env_vars` and
 `jobs` properties should be the same.
 
 ### Example of a task block with agent
 
-    version: v1.0
-    name: YAML file example with task and agent.
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-     - name: Inspect Linux environment
-       task:
-          jobs:
-            - name: Learn about SEMAPHORE_GIT_DIR
-              commands:
-                - echo $SEMAPHORE_GIT_DIR
+``` yaml
+version: v1.0
+name: YAML file example with task and agent.
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+ - name: Inspect Linux environment
+   task:
+      jobs:
+        - name: Learn about SEMAPHORE_GIT_DIR
+          commands:
+            - echo $SEMAPHORE_GIT_DIR
 
-     - name: Agent in task
-       task:
-          agent:
-              machine:
-                type: e1-standard-2
-                os_image: ubuntu1804
-          jobs:
-            - name: Using agent job
-              commands:
-                - echo $PATH
+ - name: Agent in task
+   task:
+      agent:
+          machine:
+            type: e1-standard-2
+            os_image: ubuntu1804
+      jobs:
+        - name: Using agent job
+          commands:
+            - echo $PATH
+```
 
 ## Jobs
 
@@ -486,19 +492,21 @@ will be executed for a job.
 
 The general structure of a job when using the `commands` property is as follows:
 
-    version: v1.0
-    name: The name of the Semaphore 2.0 project
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-       task:
-          jobs:
-            - name: Check environment variables
-              commands:
-                - echo $SEMAPHORE_PIPELINE_ID
-                - pwd
+``` yaml
+version: v1.0
+name: The name of the Semaphore 2.0 project
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+   task:
+      jobs:
+        - name: Check environment variables
+          commands:
+            - echo $SEMAPHORE_PIPELINE_ID
+            - pwd
+```
 
 ### commands_file
 
@@ -515,26 +523,30 @@ properties are missing.
 
 The contents of the YAML file that defines the pipeline are as follows:
 
-    version: v1.0
-    name: Using commands_file
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-     - name: Calling text file
-       task:
-          jobs:
-            - name: Using command_file
-              commands_file: file_with_commands
-          prologue:
-              commands:
-                - checkout
+``` yaml
+version: v1.0
+name: Using commands_file
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+ - name: Calling text file
+   task:
+      jobs:
+        - name: Using command_file
+          commands_file: file_with_commands
+      prologue:
+          commands:
+            - checkout
+```
 
 The contents of `file_with_commands` are as follows:
 
-	echo "Command File"
-	echo "Exit command_file"
+``` bash
+echo "Command File"
+echo "Exit command_file"
+```
 
 Some information about what happens behind the scenes: Semaphore 2.0
 reads the plain text file and creates the equivalent job using a
@@ -557,48 +569,50 @@ were also defined on the `task` level.
 
 #### Example of env_vars in jobs
 
-	version: v1.0
-	name: Using env_vars per jobs
-	agent:
-	  machine:
-	    type: e1-standard-2
-	    os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: Using env_vars per jobs
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-	blocks:
-	  - name: Using Local Environment variables only
-	    task:
-	      jobs:
-	      - name: Job that uses local env_vars
-	        commands:
-	          - echo $APP_ENV
-	        env_vars:
-	          - name: APP_ENV
-	            value: This is APP_ENV
-	          - name: VAR_2
-	            value: This is VAR_2 from First Job
+blocks:
+  - name: Using Local Environment variables only
+    task:
+      jobs:
+      - name: Job that uses local env_vars
+        commands:
+          - echo $APP_ENV
+        env_vars:
+          - name: APP_ENV
+            value: This is APP_ENV
+          - name: VAR_2
+            value: This is VAR_2 from First Job
 
-	  - name: Both local end global env_vars
-	    task:
-	      env_vars:
-	        - name: APP_ENV
-	          value: prod
-	        - name: VAR_1
-	          value: VAR_1 from outer env_vars
-	      jobs:
-	      - name: Using both global and local env_vars
-	        commands:
-	          - echo $VAR_1
-	          - echo $VAR_2
-	          - echo $APP_ENV
-	        env_vars:
-	          - name: VAR_1
-	            value: This is VAR_1
-	          - name: VAR_2
-	            value: This is VAR_2
-	      - name: Second job - no local env_vars
-	        commands:
-	          - echo $VAR_1
-	          - echo $APP_ENV
+  - name: Both local end global env_vars
+    task:
+      env_vars:
+        - name: APP_ENV
+          value: prod
+        - name: VAR_1
+          value: VAR_1 from outer env_vars
+      jobs:
+      - name: Using both global and local env_vars
+        commands:
+          - echo $VAR_1
+          - echo $VAR_2
+          - echo $APP_ENV
+        env_vars:
+          - name: VAR_1
+            value: This is VAR_1
+          - name: VAR_2
+            value: This is VAR_2
+      - name: Second job - no local env_vars
+        commands:
+          - echo $VAR_1
+          - echo $APP_ENV
+```
 
 ### matrix
 
@@ -616,26 +630,28 @@ variables from corresponding element of Cartesian product.
 
 The following pipeline illustrates the use of the `matrix` property:
 
-	version: v1.0
-	name: Using the matrix property
-	agent:
-	  machine:
-	    type: e1-standard-2
-	    os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: Using the matrix property
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-	blocks:
-	  - name: Elixir + Erlang
-	    task:
-	        jobs:
-	        - name: Elixir + Erlang matrix
-	          commands:
-	            - echo $ELIXIR
-	            - echo $ERLANG
-	          matrix:
-	            - env_var: ELIXIR
-	              values: ["1.3", "1.4"]
-	            - env_var: ERLANG
-	              values: ["19", "20", "21"]
+blocks:
+  - name: Elixir + Erlang
+    task:
+        jobs:
+        - name: Elixir + Erlang matrix
+          commands:
+            - echo $ELIXIR
+            - echo $ERLANG
+          matrix:
+            - env_var: ELIXIR
+              values: ["1.3", "1.4"]
+            - env_var: ERLANG
+              values: ["19", "20", "21"]
+```
 
 In this example, the job specification named `Elixir + Erlang matrix` expands
 to 6 parallel jobs as there are 2 * 3 = 6 combinations of the provided
@@ -665,23 +681,25 @@ fails to execute for some reason.
 
 ### Example of prologue
 
-    version: v1.0
-    name: YAML file illustrating the prologue property
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-     - name: Display a file
-       task:
-          jobs:
-            - name: Display hw.go
-              commands:
-                - ls -al
-                - cat hw.go
-          prologue:
-              commands:
-                - checkout
+``` yaml
+version: v1.0
+name: YAML file illustrating the prologue property
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+ - name: Display a file
+   task:
+      jobs:
+        - name: Display hw.go
+          commands:
+            - ls -al
+            - cat hw.go
+      prologue:
+          commands:
+            - checkout
+```
 
 ### The Epilogue property
 
@@ -691,9 +709,25 @@ a job has finished, either successfully or unsuccessfully.
 Please notice that a pipeline *will not fail* if one or more commands in the
 `epilogue` fail to execute for some reason.
 
+There are three types of epilogue commands:
+
+1. Epilogue commands that are always executed. Defined with `always` in the
+   epilogue section.
+
+2. Epilogue commands that are executed when the job passes. Defined with
+  `on_pass` in the epilogue section.
+
+3. Epilogue commands that are executed when the job fails. Defined with
+   `on_fail` in the epilogue sections.
+
+The order of command execution is the following:
+
+- First, the `always` commands are executed
+- Then the `on_pass` or `on_fail` commands are executed
+
 ### Example of epilogue
 
-<pre><code class="language-yaml">
+``` yaml
 version: v1.0
 name: YAML file illustrating the epilogue property
 agent:
@@ -708,11 +742,16 @@ blocks:
           commands:
             - uname -a
       epilogue:
+        always:
           commands:
-            - if [ "$SEMAPHORE_JOB_RESULT" = "passed" ]; then echo "This command runs if job has passed"; fi
-            - if [ "$SEMAPHORE_JOB_RESULT" = "failed" ]; then echo "This command runs if job has failed"; fi
-            - echo "this command runs in any case"
-</code></pre>
+            - echo "this command is executed for both passed and failed jobs"
+        on_pass:
+          commands:
+            - echo "This command runs if job has passed"
+        on_fail:
+          commands:
+            - echo "This command runs if job has failed"
+```
 
 ## The secrets property
 
@@ -755,47 +794,51 @@ Virtual Machine (VM), which is `/home/semaphore`.
 
 ### Example of secrets with environment variables
 
-    version: v1.0
-    name: Pipeline configuration with secrets
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-      - task:
-          jobs:
-            - name: Using secrets
-              commands:
-                - echo $USERNAME
-                - echo $PASSWORD
-          secrets:
-            - name: mysql-secrets
+``` yaml
+version: v1.0
+name: Pipeline configuration with secrets
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - task:
+      jobs:
+        - name: Using secrets
+          commands:
+            - echo $USERNAME
+            - echo $PASSWORD
+      secrets:
+        - name: mysql-secrets
+```
 
 Environment variables imported from a `secrets` property are used like regular
 environment variables defined in a `env_vars` block.
 
 ### Example of secrets with files
 
-    version: v1.0
-    name: Using files in secrets in Semaphore 2.0
-    agent:
-       machine:
-         type: e1-standard-2
-         os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: Using files in secrets in Semaphore 2.0
+agent:
+   machine:
+     type: e1-standard-2
+     os_image: ubuntu1804
 
-    blocks:
-    - task:
-          jobs:
-            - name: file.txt
-              commands:
-                - checkout
-                - ls -l ~/file.txt
-                - cd ..
-                - cat file.txt
-                - echo $SECRET_ONE
-          secrets:
-            - name: more-secrets
-            - name: my-secrets
+blocks:
+- task:
+      jobs:
+        - name: file.txt
+          commands:
+            - checkout
+            - ls -l ~/file.txt
+            - cd ..
+            - cat file.txt
+            - echo $SECRET_ONE
+      secrets:
+        - name: more-secrets
+        - name: my-secrets
+```
 
 In this case the name of the file that was saved in a `secret` is `file.txt`
 and is located at the home directory of the VM.
@@ -842,27 +885,29 @@ exist – the error will be revealed at the time of promotion.
 
 The contents of the `.semaphore/semaphore.yml` are as follows:
 
-    version: v1.0
-    name: Using promotions
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: Using promotions
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    blocks:
-      - name: ls
-        task:
-          jobs:
-          - name: List contents
-            commands:
-              - ls -al
-              - echo $SEMAPHORE_PIPELINE_ID
+blocks:
+  - name: ls
+    task:
+      jobs:
+      - name: List contents
+        commands:
+          - ls -al
+          - echo $SEMAPHORE_PIPELINE_ID
 
-    promotions:
-      - name: Pipeline 1
-        pipeline_file: p1.yml
-      - name: Pipeline 2
-        pipeline_file: p2.yml
+promotions:
+  - name: Pipeline 1
+    pipeline_file: p1.yml
+  - name: Pipeline 2
+    pipeline_file: p2.yml
+```
 
 The `promotions` block in the aforementioned `.semaphore/semaphore.yml` file
 will allow you to promote two other YAML files named `p1.yml` and
@@ -870,38 +915,42 @@ will allow you to promote two other YAML files named `p1.yml` and
 
 The contents of the `.semaphore/p1.yml` are as follows:
 
-    version: v1.0
-    name: This is Pipeline 1
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: This is Pipeline 1
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    blocks:
-      - name: Environment variable
-        task:
-          jobs:
-          - name: SEMAPHORE_PIPELINE_ID
-            commands:
-              - echo $SEMAPHORE_PIPELINE_ID
+blocks:
+  - name: Environment variable
+    task:
+      jobs:
+      - name: SEMAPHORE_PIPELINE_ID
+        commands:
+          - echo $SEMAPHORE_PIPELINE_ID
+```
 
 Last, the contents of the `.semaphore/p2.yml` are as follows:
 
-    version: v1.0
-    name: This is Pipeline 2
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: This is Pipeline 2
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    blocks:
-      - name: List VM Linux version
-        task:
-          jobs:
-          - name: uname
-            commands:
-              - echo $SEMAPHORE_PIPELINE_ID
-              - uname -a
+blocks:
+  - name: List VM Linux version
+    task:
+      jobs:
+      - name: uname
+        commands:
+          - echo $SEMAPHORE_PIPELINE_ID
+          - uname -a
+```
 
 ### auto\_promote\_on
 
@@ -980,49 +1029,51 @@ For a `result` value of `failed`, the valid values of `result_reason` are
 The following pipeline YAML file presents an example use of `auto_promote_on`
 and depends on two other pipeline YAML files named `p1.yml` and `p2.yml`:
 
-    version: v1.0
-    name: Testing Auto Promoting
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: Testing Auto Promoting
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    promotions:
-    - name: Staging
-      pipeline_file: p1.yml
-      auto_promote_on:
-        - result: passed
-          branch:
-            - "master"
-        - result: failed
-          branch:
-            - "v2."
-          result_reason: malformed
+promotions:
+- name: Staging
+  pipeline_file: p1.yml
+  auto_promote_on:
+    - result: passed
+      branch:
+        - "master"
+    - result: failed
+      branch:
+        - "v2."
+      result_reason: malformed
 
-    - name: prod
-      pipeline_file: p2.yml
+- name: prod
+  pipeline_file: p2.yml
 
-    blocks:
-      - name: Block 1
-        task:
-          jobs:
-            - name: Job 1 - Block 1
-              commands:
-                - echo $SEMAPHORE_GIT_BRANCH
-            - name: Job 2 - Block 1
-              commands:
-                - echo Job 2 - Block 1
+blocks:
+  - name: Block 1
+    task:
+      jobs:
+        - name: Job 1 - Block 1
+          commands:
+            - echo $SEMAPHORE_GIT_BRANCH
+        - name: Job 2 - Block 1
+          commands:
+            - echo Job 2 - Block 1
 
-      - name: Block 2
-        task:
-          jobs:
-            - name: Job 1 - Block 2
-              commands:
-                - echo Job 1 - Block 2
-                - echo $SEMAPHORE_GIT_BRANCH
-            - name: Job 2 - Block 2
-              commands:
-                - echo Job 2 - Block 2
+  - name: Block 2
+    task:
+      jobs:
+        - name: Job 1 - Block 2
+          commands:
+            - echo Job 1 - Block 2
+            - echo $SEMAPHORE_GIT_BRANCH
+        - name: Job 2 - Block 2
+          commands:
+            - echo Job 2 - Block 2
+```
 
 According to the specified rules only the `Staging` promotion of the `promotions`
 list can be auto promoted – this depends on the rules of the two items of
@@ -1040,38 +1091,42 @@ one or more characters.
 
 The contents of `p1.yml` are as follows:
 
-    version: v1.0
-    name: Pipeline 1
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: Pipeline 1
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    blocks:
-      - name: Environment variable
-        task:
-          jobs:
-          - name: SEMAPHORE_PIPELINE_ID
-            commands:
-              - echo $SEMAPHORE_PIPELINE_ID
+blocks:
+  - name: Environment variable
+    task:
+      jobs:
+      - name: SEMAPHORE_PIPELINE_ID
+        commands:
+          - echo $SEMAPHORE_PIPELINE_ID
+```
 
 The contents of `p2.yml` are the following:
 
-    version: v1.0
-    name: This is Pipeline 2
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: This is Pipeline 2
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    blocks:
-      - name: List VM Linux version
-        task:
-          jobs:
-          - name: uname
-            commands:
-              - echo $SEMAPHORE_PIPELINE_ID
-              - uname -a
+blocks:
+  - name: List VM Linux version
+    task:
+      jobs:
+      - name: uname
+        commands:
+          - echo $SEMAPHORE_PIPELINE_ID
+          - uname -a
+```
 
 Both `p1.yml` and `p2.yml` are perfectly correct pipeline YAML files that could
 have been used as `semaphore.yml` files.
@@ -1082,74 +1137,84 @@ have been used as `semaphore.yml` files.
 
 The following code presents a complete `.semaphore/semaphore.yml` file:
 
-    version: v1.0
-    name: YAML file example for Go project
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
+``` yaml
+version: v1.0
+name: YAML file example for Go project
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
 
-    blocks:
-     - name: Inspect Linux environment
-       task:
-          jobs:
-            - name: Execute hw.go
-              commands:
-                - echo $SEMAPHORE_PIPELINE_ID
-                - echo $HOME
-                - echo $SEMAPHORE_GIT_DIR
-                - echo $PI
-          prologue:
-              commands:
-                - checkout
-          env_vars:
-               - name: PI
-                 value: "3.14159"
+blocks:
+ - name: Inspect Linux environment
+   task:
+      jobs:
+        - name: Execute hw.go
+          commands:
+            - echo $SEMAPHORE_PIPELINE_ID
+            - echo $HOME
+            - echo $SEMAPHORE_GIT_DIR
+            - echo $PI
+      prologue:
+          commands:
+            - checkout
+      env_vars:
+           - name: PI
+             value: "3.14159"
 
-     - name: Build Go project
-       task:
-          jobs:
-            - name: Build hw.go
-              commands:
-                - checkout
-                - change-go-version 1.10
-                - go build hw.go
-                - ./hw
-            - name: PATH variable
-              commands:
-                - echo $PATH
-          epilogue:
-              commands:
-                - echo $SEMAPHORE_JOB_RESULT
-                - echo $SEMAPHORE_PIPELINE_ID
+ - name: Build Go project
+   task:
+      jobs:
+        - name: Build hw.go
+          commands:
+            - checkout
+            - change-go-version 1.10
+            - go build hw.go
+            - ./hw
+        - name: PATH variable
+          commands:
+            - echo $PATH
+      epilogue:
+        always:
+          commands:
+            - echo "The job finished with: $SEMAPHORE_JOB_RESULT"
+        on_pass:
+          commands:
+            - echo "Executed when the SEMAPHORE_JOB_RESULT is passed"
+        on_fail:
+          commands:
+            - echo "Executed when the SEMAPHORE_JOB_RESULT is failed"
+```
 
 ### A .semaphore/semaphore.yml file that uses secrets
 
-    version: v1.0
-    name: Pipeline configuration with secrets
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-      - task:
-          jobs:
-            - name: Using secrets
-              commands:
-                - checkout
-                - ls -l .semaphore
-                - echo $SEMAPHORE_PIPELINE_ID
-                - echo $SECRET_ONE
-                - echo $SECRET_TWO
-            - name: Using SECRET_TWO
-              commands:
-                - checkout
-                - echo $SECRET_TWO
-                - ls -l .semaphore
+``` yaml
+version: v1.0
+name: Pipeline configuration with secrets
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - task:
+      jobs:
+        - name: Using secrets
+          commands:
+            - checkout
+            - ls -l .semaphore
+            - echo $SEMAPHORE_PIPELINE_ID
+            - echo $SECRET_ONE
+            - echo $SECRET_TWO
+        - name: Using SECRET_TWO
+          commands:
+            - checkout
+            - echo $SECRET_TWO
+            - ls -l .semaphore
 
-          secrets:
-            - name: mySecrets
-            - name: more-mihalis-secrets
+      secrets:
+        - name: mySecrets
+        - name: more-mihalis-secrets
+```
 
 ### A .semaphore/semaphore.yml file without name properties
 
@@ -1160,18 +1225,20 @@ avoided.
 However, the following sample `.semaphore/semaphore.yml` file proves
 that it can be done:
 
-    version: v1.0
-    name: Basic YAML configuration file example.
-    agent:
-      machine:
-        type: e1-standard-2
-        os_image: ubuntu1804
-    blocks:
-      - task:
-          jobs:
-              - commands:
-                 - echo $SEMAPHORE_PIPELINE_ID
-                 - echo "Hello World!"
+``` yaml
+version: v1.0
+name: Basic YAML configuration file example.
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - task:
+      jobs:
+          - commands:
+             - echo $SEMAPHORE_PIPELINE_ID
+             - echo "Hello World!"
+```
 
 ## The order of execution
 


### PR DESCRIPTION
I've done two things in this PR:

1. Converted code examples to fenced code blocks
2. Introduced on_pass, on_fail commands

The first change makes it hard to review the changes only. I partially regret that I've done it in the same pull request. To make the review easier, I'll link to parts that have actually changed:

- https://github.com/semaphoreci/docs/pull/352/files#diff-afe7f673657d51f4be42da7d90345460R704
- https://github.com/semaphoreci/docs/pull/352/files#diff-afe7f673657d51f4be42da7d90345460R1177

---

Edit: 

I've used fenced code blocks instead of `<pre><code class="language-yaml">` because I think this is the right choice for future maintainability of the docs.

The relevant renderer should be adjusted here to include the language class extracted from the fenced code block:

https://github.com/semaphoreci/docs/blob/master/lib/docs_renderer.rb#L9

I'll introduce this change in another PR.