### PR TITLE
Update Ubuntu 18.04 and MacOS Mojave image documentation

### DIFF
--- a/machine-types_5b24032b0428632c466af399.md
+++ b/machine-types_5b24032b0428632c466af399.md
@@ -1,15 +1,12 @@
-- [Overview](#overview)
-- [Linux machine types](#linux-machine-types)
-- [Apple machine type](#apple-machine-type)
-
-## Overview
-
 A **machine type** specifies a particular collection of virtualized
 hardware resources available to a virtual machine (VM) instance,
 including the memory size, virtual CPU count, and disk.
 
 This guide describes the available machine types. For using the supported
 machine types in pipelines see pipeline [agent documentation][agent].
+
+- [Linux machine types](#linux-machine-types)
+- [Apple machine type](#apple-machine-type)
 
 ## Linux machine types
 
@@ -78,7 +75,7 @@ Linux machine types can be paired with the [Ubuntu1804 image][ubuntu1804].
 </tbody>
 </table>
 
-### Implementation of `e1` series of machine types
+Implementation of `e1` series of machine types:
 
 1. Virtual CPU is implemented as a single hardware hyper-thread on a
    3.4GHz, Max Turbo 4.0GHz Intel® Core™ i7.

--- a/machine-types_5b24032b0428632c466af399.md
+++ b/machine-types_5b24032b0428632c466af399.md
@@ -2,8 +2,9 @@ A **machine type** specifies a particular collection of virtualized
 hardware resources available to a virtual machine (VM) instance,
 including the memory size, virtual CPU count, and disk.
 
-This guide describes the available machine types. For using the supported
-machine types in pipelines see pipeline [agent documentation][agent].
+This guide describes the available machine types. For instructions about using
+the supported machine types in pipelines see pipeline
+[agent documentation][agent].
 
 - [Linux machine types](#linux-machine-types)
 - [Apple machine type](#apple-machine-type)

--- a/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
+++ b/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
@@ -1,4 +1,12 @@
-- [Overview](#overview)
+The `macos-mojave` is a customized image based on [MacOS 10.14][mojave-release-notes]
+optimized for CI/CD. It comes with a set of preinstalled languages, databases,
+and utility tools commonly used for CI/CD workflows. The image can be paired
+with any [Apple machine type][machine-types] when defining the [agent][agent]
+of your pipeline or block.
+
+The `macos-mojave` is a virtual machine image. The user in the environment,
+named `semaphore`, has full `sudo` access.
+
 - [Version control](#version-control)
 - [Utilities](#utilities)
 - [Gems](#gems)
@@ -9,21 +17,34 @@
 - [Xcode](#xcode)
 - [See also](#see-also)
 
-## Overview
-
-The `macos-mojave` image is based on [MacOS 10.14][mojave-release-notes].
-You can use it to build, test and deliver iOS and MacOS projects.
-The user in the environment is named `semaphore`, and has full `sudo` access.
-
-Image name: `macos-mojave`
-
-OS: `Darwin Kernel Version 18.2.0`
-
-This image can be paired with [Apple machine types][machine-types] when defining
-the [agent][agent] of your pipeline or block.
-
 Note: MacOS support on Semaphore is currently in private beta. To get access,
 [please apply][beta-form].
+
+## Using the macos-mojave OS image in your agent configuration
+
+To use the `macos-mojave` OS image, define it as the `os_image` of your agent's
+machine.
+
+``` yaml
+version: 1.0
+name: Apple/Mojave Based Pipeline
+
+agent:
+  machine:
+    type: a1-standard-4
+    os_image: macos-mojave
+
+blocks:
+  - name: "Unit tests"
+    task:
+      jobs:
+        - name: Tests
+          commands:
+            - make test
+```
+
+The `macos-mojave` OS image can only be used in combination with an Apple
+machine type `a1-standard-4`.
 
 ## Version control
 

--- a/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
+++ b/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
@@ -4,7 +4,7 @@ and utility tools commonly used for CI/CD workflows. The image can be paired
 with any [Apple machine type][machine-types] when defining the [agent][agent]
 of your pipeline or block.
 
-The `macos-mojave` is a virtual machine image. The user in the environment,
+The `macos-mojave` is a virtual machine (VM) image. The user in the environment,
 named `semaphore`, has full `sudo` access.
 
 - [Version control](#version-control)
@@ -17,8 +17,7 @@ named `semaphore`, has full `sudo` access.
 - [Xcode](#xcode)
 - [See also](#see-also)
 
-Note: MacOS support on Semaphore is currently in private beta. To get access,
-[please apply][beta-form].
+Note: MacOS support on Semaphore is currently in beta.
 
 ## Using the macos-mojave OS image in your agent configuration
 

--- a/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
+++ b/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
@@ -7,6 +7,7 @@ of your pipeline or block.
 The `macos-mojave` is a virtual machine (VM) image. The user in the environment,
 named `semaphore`, has full `sudo` access.
 
+- [Using the macos-mojave OS image in your agent configuration](#using-the-macos-mojave-OS-image-in-your-agent-configuration)
 - [Version control](#version-control)
 - [Utilities](#utilities)
 - [Gems](#gems)

--- a/ubuntu-1804-image_5b461f730428630abc0bf442.md
+++ b/ubuntu-1804-image_5b461f730428630abc0bf442.md
@@ -53,7 +53,7 @@ blocks:
 ```
 
 The `ubuntu1804` OS image can be used in combination with all Linux machine
-types `e1-standard-2`, `e1-standard-4`, `e1-standard-8`.
+types: `e1-standard-2`, `e1-standard-4`, `e1-standard-8`.
 
 ## Version control
 

--- a/ubuntu-1804-image_5b461f730428630abc0bf442.md
+++ b/ubuntu-1804-image_5b461f730428630abc0bf442.md
@@ -1,4 +1,13 @@
-- [Overview](#overview)
+The `ubuntu1804` is a customized image based on [Ubuntu 18.04 LTS](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes)
+optimized for CI/CD. It comes with a set of preinstalled languages, databases,
+and utility tools commonly used for CI/CD workflows. The image can be paired
+with any [Linux machine type][machine-types] when defining the [agent][agent]
+of your pipeline or block.
+
+The `ubuntu1804` is a virtual machine image. The user in the environment, named
+`semaphore`, has full `sudo` access.
+
+- [Using the ubuntu1804 OS image in your agent configuration](#using-the-ubuntu1804-OS-image-in-your-agent-configuration)
 - [Version control](#version-control)
 - [Browsers and Headless Browser Testing](#browsers-and-headless-browser-testing)
 - [Docker](#docker)
@@ -16,19 +25,35 @@
 - [Rust](#Rust)
 - [See also](#see-also)
 
-## Overview
-
-The `ubuntu1804` image is based on [Ubuntu 18.04 LTS](https://wiki.ubuntu.com/BionicBeaver/ReleaseNotes).
-The user in the environment is named `semaphore`, and has full `sudo` access.
-
-Image name: `ubuntu1804`
-
-This image can be paired with [Linux machine types][machine-types] when defining
-the [agent][agent] of your pipeline or block.
-
 The `ubuntu1804` Virtual Machine uses an *APT mirror* that is in the same data
 center as our build cluster, which means that caching packages will have little
 effect.
+
+## Using the ubuntu1804 OS image in your agent configuration
+
+To use the `ubuntu1804` OS image, define it as the `os_image` of your agent's
+machine.
+
+``` yaml
+version: 1.0
+name: Ubuntu18 Based Pipeline
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: "Unit tests"
+    task:
+      jobs:
+        - name: Tests
+          commands:
+            - make test
+```
+
+The `ubuntu1804` OS image can be used in combination with all Linux machine
+types `e1-standard-2`, `e1-standard-4`, `e1-standard-8`.
 
 ## Version control
 

--- a/ubuntu-1804-image_5b461f730428630abc0bf442.md
+++ b/ubuntu-1804-image_5b461f730428630abc0bf442.md
@@ -4,8 +4,8 @@ and utility tools commonly used for CI/CD workflows. The image can be paired
 with any [Linux machine type][machine-types] when defining the [agent][agent]
 of your pipeline or block.
 
-The `ubuntu1804` is a virtual machine image. The user in the environment, named
-`semaphore`, has full `sudo` access.
+The `ubuntu1804` is a virtual machine (VM) image. The user in the environment,
+named `semaphore`, has full `sudo` access.
 
 - [Using the ubuntu1804 OS image in your agent configuration](#using-the-ubuntu1804-OS-image-in-your-agent-configuration)
 - [Version control](#version-control)
@@ -25,8 +25,8 @@ The `ubuntu1804` is a virtual machine image. The user in the environment, named
 - [Rust](#Rust)
 - [See also](#see-also)
 
-The `ubuntu1804` Virtual Machine uses an *APT mirror* that is in the same data
-center as our build cluster, which means that caching packages will have little
+The `ubuntu1804` VM uses an *APT mirror* that is in the same data center as
+Semaphore's build cluster, which means that caching packages will have little
 effect.
 
 ## Using the ubuntu1804 OS image in your agent configuration


### PR DESCRIPTION
Several small steps:

- Remove overview, jump straight to the point
- Be explicit that this is a Virtual Machine image (not a docker image)
- Give example usage