### PR TITLE
Render TOC in documents

### DIFF
--- a/lib/docs_renderer.rb
+++ b/lib/docs_renderer.rb
@@ -5,6 +5,19 @@ class DocsRenderer < Redcarpet::Render::HTML
     }.merge(extensions))
   end
 
+  def preprocess(document)
+    @document = document
+  end
+
+  def paragraph(content)
+    if ['[TOC]', '{:toc}'].include?(content)
+      toc_render = Redcarpet::Render::HTML_TOC.new(nesting_level: 3)
+      parser     = Redcarpet::Markdown.new(toc_render)
+
+      return parser.render(@document)
+    end
+  end
+
   def block_code(code, language)
     %(<pre><code class="language-#{language}">#{code}</code></pre>)
   end

--- a/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
+++ b/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
@@ -7,7 +7,7 @@ of your pipeline or block.
 The `macos-mojave` is a virtual machine (VM) image. The user in the environment,
 named `semaphore`, has full `sudo` access.
 
-[[_TOC_]]
+[TOC]
 
 Note: MacOS support on Semaphore is currently in beta.
 


### PR DESCRIPTION
Manually maintaining TOCs in documents is hassle. We have several "broken" links in the docuemnts.

This new `[TOC]` helper should help us out and streamline this process.