### PR TITLE
Replace [[__TOC__]] with table of content in documents

### DIFF
--- a/lib/docs_renderer.rb
+++ b/lib/docs_renderer.rb
@@ -5,6 +5,18 @@ class DocsRenderer < Redcarpet::Render::HTML
     }.merge(extensions))
   end
 
+  def preprocess(document)
+    # replace [[__TOC__]] with table of content
+
+    toc_render = Redcarpet::Render::HTML_TOC.new(nesting_level: 3)
+    parser     = Redcarpet::Markdown.new(toc_render)
+    toc        = parser.render(document)
+
+    document.sub!("[[__TOC__]]", toc)
+
+    document
+  end
+
   def block_code(code, language)
     %(<pre><code class="language-#{language}">#{code}</code></pre>)
   end

--- a/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
+++ b/macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md
@@ -7,7 +7,7 @@ of your pipeline or block.
 The `macos-mojave` is a virtual machine (VM) image. The user in the environment,
 named `semaphore`, has full `sudo` access.
 
-[TOC]
+[[__TOC__]]
 
 Note: MacOS support on Semaphore is currently in beta.
 


### PR DESCRIPTION
I tried several approaches. This one with simple string substitution works the best IMHO.

This should solve two issues:

- It removes the possibility of broken links in TOCs
- No need to manually maintain the table of content on pages