### PR TITLE
Disable Markdown lint

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,11 +9,11 @@ blocks:
   - name: "Tests"
     task:
       jobs:
-        - name: "Markdown Link"
-          commands:
-            - npm install -g markdownlint-cli
-            - checkout
-            - markdownlint *.md
+        #- name: "Markdown Lint"
+        #  commands:
+        #    - npm install -g markdownlint-cli
+        #    - checkout
+        #    - markdownlint *.md
 
         - name: List of changes for manual inspection
           commands:


### PR DESCRIPTION
This creates overhead as we get contributions from forks, which S2 doesn't support yet.
So the person who's working on an update can't make required adjustments.

/cc @shiroyasha 