### PR TITLE
Create secret with Env Vars the same way you would inject an environment variable into Docker

### DIFF
--- a/docker-dockerhub_5bb9dcf5042863158cc72368.md
+++ b/docker-dockerhub_5bb9dcf5042863158cc72368.md
@@ -35,7 +35,7 @@ blocks:
     task:
       # Pull in environment variables from the "docker" secret
       secrets:
-        - name: docker
+        - name: dockerhub-secrets
       prologue:
         commands:
           # Authenticate to the registry for all jobs in the block

--- a/docker-dockerhub_5bb9dcf5042863158cc72368.md
+++ b/docker-dockerhub_5bb9dcf5042863158cc72368.md
@@ -6,26 +6,10 @@ first step is create a secret for `DOCKER_USERNAME` and
 
 ## Creating The Secret
 
-Open a new `secret.yml` file:
-
-``` yaml
-# secret.yml
-apiVersion: v1alpha
-kind: Secret
-metadata:
-  name: docker
-data:
-  env_vars:
-    - name: DOCKER_USERNAME
-      value: "REPLACE WITH YOUR USERNAME"
-    - name: DOCKER_PASSWORD
-      value: "REPLACE WITH YOUR PASSWORD"
-```
-
-Then create it:
-
 ``` bash
-sem create -f secret.yml
+sem create secret dockerhub-secrets \
+  -e DOCKER_USERNAME=<your-dockerhub-username> \
+  -e DOCKER_PASSWORD=<your-dockerhub-password>
 ```
 
 Now add the secret to your pipeline and authenticate.

--- a/docker-ecr_5bb9dd262c7d3a04dd5b5e81.md
+++ b/docker-ecr_5bb9dd262c7d3a04dd5b5e81.md
@@ -5,26 +5,10 @@ secret to configure AWS access key environment variables.
 
 ## Creating the Secret
 
-Open a new `secret.yml` file:
-
-``` yaml
-# secret.yml
-apiVersion: v1alpha
-kind: Secret
-metadata:
-  name: AWS
-data:
-  env_vars:
-    - name: AWS_ACCESS_KEY_ID
-      value: "YOUR_ACCESS_KEY"
-    - name: AWS_SECRET_ACCESS_KEY
-      value: "YOUR_SECRET_ACCESS_KEY"
-```
-
-Then create it:
-
 ``` bash
-sem create -f secret.yml
+sem create secret AWS \
+  -e AWS_ACCESS_KEY_ID=<your-aws-key-id> \
+  -e AWS_SECRET_ACCESS_KEY=<your-aws-access-key>
 ```
 
 Now add the secret to your pipeline and authenticate

--- a/docker-gcr_5bb9dd402c7d3a04dd5b5e82.md
+++ b/docker-gcr_5bb9dd402c7d3a04dd5b5e82.md
@@ -8,22 +8,16 @@ the registries.
 
 ## Create the Secret
 
-1. Base64 encode the `key.json` and save the output: `base64 key.json`
-1. Create a new file `secret.yml` and paste in the content:
+Assuming that your Google Cloud credentials are stored on your computer in
+`/home/<username>/.secrets/gcp.json` use the following command to create a
+secret on Semaphore:
 
-```yml
-# secret.yml
-apiVersion: v1alpha
-kind: Secret
-metadata:
-  name: GCP
-data:
-  files:
-    - path: .secrets.gcp.json
-      content: PASTE_BASE64_ENCODED_CONTENT_HERE
+``` bash
+sem create secret GCP \
+  -f /home/<username>/.secrets/gcp.json:.secrets/gcp.json
 ```
 
-1. Create the `GCP` secret with `sem`: `sem create -f secret.yml`
+Now add the secret to your pipeline and authenticate.
 
 ## Configure the Pipeline
 

--- a/sem-reference_5b6968642c7d3a03f89d6bff.md
+++ b/sem-reference_5b6968642c7d3a03f89d6bff.md
@@ -332,65 +332,30 @@ sem create dashboard my-dashboard
 You cannot execute `sem create project [name]` in order to create an empty
 Semaphore 2.0 project.
 
-#### Adding one or more files in a new secret
+##### sem create secret with environment variables and files
 
-There exists a unique way for adding one or more files and creating a new
-`secret` with them that uses the `sem create` command. The general form of the
-command is the following:
+To create a secret with a list of environment variables and files, you can pass
+them during creation.
 
-``` bash
-sem create secret [NAME] -f local1:secret1 [-f local2:secret2]
-```
-
-Each entry has two parts, which are the path to the local file and the path to
-the file as it will appear in the `secret`. This is very convenient as you do
-not have to rename the local files before inserting them to the `secret`.
-
-After that you can edit, delete or use that new `secret` as usual.
-
-The only downside of this method is that after creating a `secret` you can only
-add more environment variables and files by editing the `secret`.
-
-##### sem create secret with files example
-
-Imagine that you have two files that are located at `/etc/hosts` and
-`/home/rtext/docker-secrets` that you want to add to a secret. Although you
-can manually add them to an existing secret, you can also use `sem create` with
-the following syntax:
+For example to create a secret `example-secret` with two environment variables
+and a file, use:
 
 ``` bash
-sem create secret newSecret -f /etc/hosts:/var/hosts -f /home/rtext/docker-secrets:docker-secrets
+sem create secret example-secret \
+  -e FOO=BAR \
+  -e "MESSAGE=Hello World" \
+  -f /Users/John/hello.txt:/home/semaphore/hello.txt
 ```
 
-After the execution of the aforementioned command, there will be a new secret
-named `newSecret` with two files in it. The path of the first file will be
-`/var/hosts` and the path of the second file will be `docker-secrets`.
+Use the `-f` or `--file` flag to specify one or more files. The format of the
+parameter is `<local-path>:<path-on-sempahore>`. If the `<path-on-semaphore>` is
+an absolute path, for example `/etc/hosts` it will be mounted to `/etc/hosts`.
+If the `<path-on-semaphore>` is a relative path, for example `.ssh/id_rsa_test`
+it will be mounted relative to the home directory, in this example
+`/home/semaphore/.ssh/id_rsa_test`.
 
-You can verify the results of the command as follows:
-
-``` bash
-sem get secrets newSecret
-```
-
-The output you will get from the previous command will be similar to the
-following:
-
-``` yaml
-apiVersion: v1beta
-kind: Secret
-metadata:
-  name: newSecret
-  id: 9851fa6a-681e-439c-b366-2c7283c6b363
-  create_time: "1539247272"
-  update_time: "1539247272"
-data:
-  env_vars: []
-  files:
-  - path: /var/log/hosts
-    content: IyMKMTI3LjAuMC4xCWxvY2FsaG9zdAoyNTUuMjU1LjI1NS4yNTUJYnJvYWR
-  - path: docker-secrets
-    content: ICAtIG5hbWdWU6IG1hY3Rzb3Vcwo=
-```
+Use the `-e` or `--env` flag to specify one or more environment variables. The
+format of the parameter is `<NAME>=<VALUE>`.
 
 ### sem edit
 


### PR DESCRIPTION
Example of newly available flags in Sem CLI `v0.10.0`:

```
sem create secret aws-secrets -e AWS_KEY=123
```

This is the same way you would inject an env var into Docker, so it should be familiar to a wide range of customers.

I've updated:

- the Secrets Guide. Now we prefer using flags directly over creating/editing files.
- the Sem reference document

---

This PR and the new feature are a preparetion for pulling private Docker image. There the docs will say:

1 ) Please create a secret to hold your docker keys

``` bash
sem create secret dockerhub-pull-secrets \
  -e DOCKER_CREDENTIAL_TYPE=DockerHub \
  -e DOCKERHU_PASSWORD=a \
  -e DOCKERHUB_USERNAME=b
```

2 ) Use this secret to pull images:

```
agent:
  machine:
    type: e1-standard-2

  containers:
     - name: main
        image: renderedtext/hello

   image_pull_secrets:
     - name: dockerhub-pull-secrets
```