### PR TITLE
Quotas and limits

### DIFF
--- a/quotas-and-limits_5cc850ba2c7d3a026fd42e7e.md
+++ b/quotas-and-limits_5cc850ba2c7d3a026fd42e7e.md
@@ -2,15 +2,14 @@ Semaphore 2.0 enforces usage quotas and limits to protect customers and the
 platform from unforeseen spikes in usage. As your use of Semaphore expands over
 time, your quotas may increase accordingly.
 
-If you expect a notable upcoming increase in usage, you can proactively request
-quota adjustments by sending a request to <support@semaphoreci.com>.
+- [Quotas for Maximum Parallel Running Jobs in an Organization](#quotas-for-maximum-parallel-running-jobs-in-an-organization)
+- [Pipeline and Block Execution Time Limit](#pipeline-execution-time-limit)
+- [Job Log Output Size Limit](#job-log-output-size-limit)
 
-- [Quotas for Maximum Concurrent Running Jobs in an Organization](#quotas-for-maximum-concurrent-running-jobs-in-an-organization)
+## Quotas for Maximum Parallel Running Jobs in an Organization
 
-## Quotas for Maximum Concurrent Running Jobs in an Organization
-
-Every organization has a set of quotas that dictate the maximum number of
-cuncurrently running jobs.
+Every organization has a set of quotas that define the maximum number of
+parallel running jobs.
 
 Default quotas per machine type for a newly created organization:
 
@@ -21,4 +20,61 @@ Default quotas per machine type for a newly created organization:
 | e1-standard-8 | 8             |
 | a1-standard-4 | 2             |
 
-If your organization requires more
+If your organization needs are bigger than what is provided with the default
+machine quotas, you can request an increase by sending a request to
+<support@semaphoreci.com>.
+
+## Pipeline and Block Execution Time Limit
+
+By default, every pipeline and block is limited to an hour of execution time.
+This mechanism protects your project from undesired expenses in case of jobs
+that are running longer than anticipated. A good example is an accidentally
+committed debug statement that is waiting for user input.
+
+This limit is adjustable in the Pipeline YAML.
+
+``` yaml
+version: v1.0
+name: Using execution_time_limit
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+execution_time_limit:
+  hours: 3
+
+blocks:
+  - name: Limited to 3 hours by pipeline level configuration
+    commands:
+      - sudo apt-get install piglet
+
+  - name: Limited to 15 minutes
+    execution_time_limit:
+      minutes: 15
+    commands:
+      - sudo apt-get install vim
+```
+
+For detailed explanation, see the [execution_time_limit limit section in the
+Pipeline YAML reference][execution_time_limit_reference].
+
+## Job Log Output Size Limit
+
+Semaphore collects up to 16 megabytes of raw log data from every job in a
+pipeline, which in practice roughly equals 100,000 lines of output.
+
+Logs longer than 16 megabytes are trimmed with the following message on the
+bottom:
+
+``` txt
+Content of the log is bigger than 16MB. Log is trimmed.
+```
+
+This limit is not adjustable.
+
+For collecting longer textual files, or output from long and verbose process,
+we recommend using a blob store like AWS S3 or Google Cloud Storage.
+
+[execution_time_limit_reference](https://docs.semaphoreci.com/article/50-pipeline-yaml#execution_time_limit)

--- a/quotas-and-limits_5cc850ba2c7d3a026fd42e7e.md
+++ b/quotas-and-limits_5cc850ba2c7d3a026fd42e7e.md
@@ -1,0 +1,24 @@
+Semaphore 2.0 enforces usage quotas and limits to protect customers and the
+platform from unforeseen spikes in usage. As your use of Semaphore expands over
+time, your quotas may increase accordingly.
+
+If you expect a notable upcoming increase in usage, you can proactively request
+quota adjustments by sending a request to <support@semaphoreci.com>.
+
+- [Quotas for Maximum Concurrent Running Jobs in an Organization](#quotas-for-maximum-concurrent-running-jobs-in-an-organization)
+
+## Quotas for Maximum Concurrent Running Jobs in an Organization
+
+Every organization has a set of quotas that dictate the maximum number of
+cuncurrently running jobs.
+
+Default quotas per machine type for a newly created organization:
+
+| Machine Type  | Default Quota |
+| ------------- | ------------- |
+| e1-standard-2 | 8             |
+| e1-standard-4 | 8             |
+| e1-standard-8 | 8             |
+| a1-standard-4 | 2             |
+
+If your organization requires more


### PR DESCRIPTION
This document describes various quotas and limits of Semaphore 2.0. It lives in the Reference part of the documentation.

Inspiration documentation that describes quotas on Google Cloud https://cloud.google.com/compute/quotas.