### PR TITLE
OS Image property in agents becomes optional

### DIFF
--- a/custom-ci-cd-environment-with-docker_5caf3f432c7d3a392f9ceb50.md
+++ b/custom-ci-cd-environment-with-docker_5caf3f432c7d3a392f9ceb50.md
@@ -34,7 +34,6 @@ name: Hello Docker
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
 
   containers:
     - name: main
@@ -70,7 +69,6 @@ name: Hello Docker
 agent:
   machine:
     type: e1-standard-2
-    os_image: ubuntu1804
 
   containers:
     - name: main

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -135,12 +135,19 @@ type: e1-standard-4
 
 ### os_image
 
-The `os_image` property specifies the operating system if your virtual machine.
+The `os_image` is an optional property that specifies the operating system image
+to be used in the virtual machine. If the value is not provided the default for
+the machine type is used.
 
 These are valid values for `os_image`:
 
 - `ubuntu1804` ([reference][ubuntu1804])
 - `macos-mojave` ([reference][macos-mojave])
+
+The default operating system depends on the type of the machine:
+
+- For the `e1-standard-*` machine types the default image is `ubuntu1804`
+- For the `a1-standard-*` machine types the default image is `macos-mojave`
 
 Example of `os_image` usage:
 


### PR DESCRIPTION
The main motivation for this change is to allow customers to define an agent with containers, without the need to provide the os_image parameter that feels redundant in this setup.

So far I've updated the following articles:

- Pipeline YAML
- Custom CI/CD environment

@markoa do you maybe recall which other pages could be updated?

One other that I kinda wanted to update, but ended up skipping, is the Machine Types page. It could be expanded with default OS image field. I'm 50/50 about this change atm.