### PR TITLE
Reference: Document block dependencies property

### DIFF
--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -449,8 +449,10 @@ blocks:
           - echo "output"
 ```
 
-For more examples of common CI/CD workflows check out this [repository](https://github.com/semaphoreci-demos/semaphore-demo-workflows). Here you can find
-specifications for Fan-in/Fan-out, Monorepo and Multi Platform pipelines.
+For more examples of common complex CI/CD workflows, see the
+[semaphore-demo-workflows](https://github.com/semaphoreci-demos/semaphore-demo-workflows)
+repository on GitHub. You will find specifications for fan-in/fan-out,
+monorepo and multi-platform pipelines.
 
 ### task in blocks
 

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -374,14 +374,10 @@ displayed in the Semaphore 2.0 UI.
 
 ### dependencies in blocks
 
-The `dependencies` property of a block is used to define the flow of execution
-between blocks within a pipeline.
+When your pipeline is running blocks in parallel,
+you can use the `dependencies` property to define the flow of execution for subsequent blocks.
 
-To specify that block with name `Block C` needs to be run once the
-blocks with names `Block A` and `Block B` finish, the `dependencies` property of
-the block with name `Block C` needs to be populated with corresponding names
-of the blocks which block with name `Block C` depends on.
-In the following example blocks with names `Block A` and `Block B` would be executed in parallel at the
+The following example runs `Block A` and `Block B` in parallel at the
 very beginning of a pipeline.
 
 ``` yaml
@@ -416,11 +412,42 @@ blocks:
           - echo "output"
 ```
 
-*Note*: When `dependencies` property is used to define the names of the blocks which certain block
-depends on, property becomes mandatory for all other blocks within a pipeline
-definition. Otherwise the YAML validation error is being thrown.
-In case `dependencies` property is not used in any of the blocks within a
-pipeline, blocks will be run in sequential order.
+The `dependencies` property of `Block C` makes `Block A` and `Block B` run in
+parallel. Once both are finished `Block C` will run.
+
+If you use `dependencies` property in some block, you have to specify dependencies for other blocks as well.
+Otherwise the YAML validation error will be thrown. The following specification
+is invalid, because dependencies are missing for `Block A` and `Block B`.
+
+``` yaml
+version: "v1.0"
+name: Pipeline with dependencies
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: "Block A"
+    task:
+      jobs:
+      - name: "Job A"
+        commands:
+          - echo "output"
+  - name: "Block B"
+    task:
+      jobs:
+      - name: "Job B"
+        commands:
+          - echo "output"
+  - name: "Block C"
+    dependencies: ["Block A", "Block B"]
+    task:
+      jobs:
+      - name: "Job C"
+        commands:
+          - echo "output"
+```
 
 ### task in blocks
 

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -7,6 +7,7 @@
 - [execution\_time\_limit](#execution_time_limit)
 - [Blocks](#blocks)
   - [name](#name-in-blocks)
+  - [dependencies](#dependencies-in-blocks)
   - [task](#task-in-blocks)
 - [Task](#task)
   - [jobs](#jobs)
@@ -77,12 +78,12 @@ version: v1.0
 ## name in preface
 
 The `name` property is a Unicode string that assigns a name to a Semaphore
-2.0 project and is optional. However, you should always give descriptive names
-to your Semaphore 2.0 projects.
+2.0 pipeline and is optional. However, you should always give descriptive names
+to your Semaphore 2.0 pipelines.
 
 *Note*: The `name` property can be found in other sections for defining the
 name of a job inside a `jobs` block or the name of a `task` section defined
-using `task`.
+within `task`.
 
 Example of `name` usage:
 
@@ -93,7 +94,7 @@ name: The name of the Semaphore 2.0 project
 ## agent
 
 The `agent` property defines the hardware and software environment of the
-virtual machine that runs your job(s).
+virtual machine that runs your jobs.
 
 Example of `agent` usage:
 
@@ -104,7 +105,7 @@ agent:
     os_image: ubuntu1804
 ```
 
-*Tip*: `agent` can also be defined on a [per `task` basis](#agent-in-task).
+*Note*: `agent` can also be defined on a [per `task` basis](#agent-in-task).
 
 ### machine
 
@@ -183,7 +184,7 @@ Each container entry must define the `name` and `image` property. The name of
 the container is used when linking the containers together, and for defining
 hostnames in the first container.
 
-The first containers runs the jobs' commands, while the rest of the containers
+The first container runs the jobs' commands, while the rest of the containers
 are linked via DNS records. The container with name `db` is registered with a
 hostname `db` in the first container.
 
@@ -211,7 +212,7 @@ blocks:
 ## execution\_time\_limit
 
 The concept behind the `execution_time_limit` property is simple: you do not
-want your jobs to be executed for ever and you need to be able to set a time
+want your jobs to be executed forever and you need to be able to set a time
 limit for the entire pipeline as well as for individual blocks.
 
 The `execution_time_limit` property can be used in two ways. First, with a
@@ -371,10 +372,58 @@ Error: "There are at least two blocks with same name: Build Go project"
 Semaphore assigns its own unique names to nameless `blocks` items, which are
 displayed in the Semaphore 2.0 UI.
 
+### dependencies in blocks
+
+The `dependencies` property of a block is used to define the flow of execution
+between blocks within a pipeline.
+
+To specify that block `C` needs to be run once the blocks `A` and `B` finish,
+the `dependencies` property of the block `C` needs to be populated with corresponding names of the blocks which block `C` depends on.
+In the following example blocks `A` and `B` would be executed in parallel at the
+very beginning of a pipeline.
+
+``` yaml
+version: "v1.0"
+name: Pipeline with dependencies
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: "A"
+    dependencies: []
+    task:
+      jobs:
+      - name: "A"
+        commands:
+          - echo "A"
+  - name: "B"
+    dependencies: []
+    task:
+      jobs:
+      - name: "B"
+        commands:
+          - echo "B"
+  - name: "C"
+    dependencies: ["A", "B"]
+    task:
+      jobs:
+      - name: "C"
+        commands:
+          - sleep 10
+          - echo "C"
+```
+
+*Note*: When `dependencies` property is used to define the names of the blocks which certain block
+depends on, property becomes mandatory for all other blocks within a pipeline
+definition. Otherwise the YAML validation error is being thrown.
+In case `dependencies` property is not used in any of the blocks within a
+pipeline, blocks will be run in sequential order.
+
 ### task in blocks
 
-All the items of a `blocks` list have a `task` property that at the current
-moment is required.
+All the items of a `blocks` list have a `task` property which is required.
 
 You will learn about the properties of a `task` item in a while.
 

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -421,7 +421,7 @@ is invalid, because dependencies are missing for `Block A` and `Block B`.
 
 ``` yaml
 version: "v1.0"
-name: Pipeline with dependencies
+name: Invalid pipeline
 agent:
   machine:
     type: e1-standard-2
@@ -448,6 +448,9 @@ blocks:
         commands:
           - echo "output"
 ```
+
+For more examples of common CI/CD workflows check out this [repository](https://github.com/semaphoreci-demos/semaphore-demo-workflows). Here you can find
+specifications for Fan-in/Fan-out, Monorepo and Multi Platform pipelines.
 
 ### task in blocks
 

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -377,9 +377,11 @@ displayed in the Semaphore 2.0 UI.
 The `dependencies` property of a block is used to define the flow of execution
 between blocks within a pipeline.
 
-To specify that block `C` needs to be run once the blocks `A` and `B` finish,
-the `dependencies` property of the block `C` needs to be populated with corresponding names of the blocks which block `C` depends on.
-In the following example blocks `A` and `B` would be executed in parallel at the
+To specify that block with name `Block C` needs to be run once the
+blocks with names `Block A` and `Block B` finish, the `dependencies` property of
+the block with name `Block C` needs to be populated with corresponding names
+of the blocks which block with name `Block C` depends on.
+In the following example blocks with names `Block A` and `Block B` would be executed in parallel at the
 very beginning of a pipeline.
 
 ``` yaml
@@ -391,28 +393,27 @@ agent:
     os_image: ubuntu1804
 
 blocks:
-  - name: "A"
+  - name: "Block A"
     dependencies: []
     task:
       jobs:
-      - name: "A"
+      - name: "Job A"
         commands:
-          - echo "A"
-  - name: "B"
+          - echo "output"
+  - name: "Block B"
     dependencies: []
     task:
       jobs:
-      - name: "B"
+      - name: "Job B"
         commands:
-          - echo "B"
-  - name: "C"
-    dependencies: ["A", "B"]
+          - echo "output"
+  - name: "Block C"
+    dependencies: ["Block A", "Block B"]
     task:
       jobs:
-      - name: "C"
+      - name: "Job C"
         commands:
-          - sleep 10
-          - echo "C"
+          - echo "output"
 ```
 
 *Note*: When `dependencies` property is used to define the names of the blocks which certain block

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -52,12 +52,12 @@
 This document is the reference of the YAML grammar used for describing the
 pipelines of Semaphore 2.0 projects.
 
-The core properties of a Semaphore 2.0 pipeline configuration file are
+The core properties of a Semaphore pipeline configuration file are
 `blocks`, which appear only once at the beginning of a YAML file, `task`,
 which can appear multiple times, `jobs`, which can also be repeated, and
 `promotions` that is optional and can appear only once.
 
-Each Semaphore 2.0 pipeline configuration file has a mandatory preface,
+Each Semaphore pipeline configuration file has a mandatory preface,
 which consists of properties `version`, `name` and `agent`.
 
 ## Properties
@@ -78,8 +78,8 @@ version: v1.0
 ## name in preface
 
 The `name` property is a Unicode string that assigns a name to a Semaphore
-2.0 pipeline and is optional. However, you should always give descriptive names
-to your Semaphore 2.0 pipelines.
+pipeline and is optional. However, you should always give descriptive names
+to your Semaphore pipelines.
 
 *Note*: The `name` property can be found in other sections for defining the
 name of a job inside a `jobs` block or the name of a `task` section defined
@@ -599,7 +599,7 @@ Semaphore assigns its own names to nameless `jobs` items, which is what is
 displayed in the UI.
 
 *Tip*: It is considered a good practice to give descriptive names to all the
-`jobs` and the `blocks` items of a Semaphore 2.0 pipeline.
+`jobs` and the `blocks` items of a Semaphore pipeline.
 
 ### commands
 


### PR DESCRIPTION
This PR introduces `dependencies in blocks` section within pipeline YAML reference.

It explains how the property is used along with one example snippet.

Let me know if there is something you would like to add within a reference.