### PR TITLE
Updates for CLI release v0.13.0: Debug and Attaching updates

### DIFF
--- a/debugging-with-ssh-access_5bbcbae0042863158cc73802.md
+++ b/debugging-with-ssh-access_5bbcbae0042863158cc73802.md
@@ -1,6 +1,6 @@
 Often the best way to troubleshoot failures and bugs in your pipelines is to
 SSH into a job and inspect log files, running processes, and directory paths.
-Semaphore 2.0 gives you the option to access all running jobs via SSH, to
+Semaphore gives you the option to access all running jobs via SSH, to
 restart your jobs in debug mode, or to start on-demand virtual machines to
 explore the CI/CD environment.
 
@@ -15,7 +15,7 @@ Before you begin, you'll need to [install the Semaphore CLI][install-cli].
 ## Restarting a job in debug mode
 
 Setting up a pipeline can be challenging if you are not familiar with the
-software stack installed in Semaphore 2.0 virtual machines. Starting a debug
+software stack installed in Semaphore virtual machines. Starting a debug
 session for your job is a great place to start exploring.
 
 To start a debug session for your job, run:
@@ -40,7 +40,7 @@ sem debug job [job-id] --duration 3h
 ```
 
 By default, a debug session does not include the contents of the GitHub
-repository related to your Semaphore 2.0 project. Run `checkout` in the debug
+repository related to your Semaphore project. Run `checkout` in the debug
 session to clone your repository.
 
 ### Error: project or job not found

--- a/debugging-with-ssh-access_5bbcbae0042863158cc73802.md
+++ b/debugging-with-ssh-access_5bbcbae0042863158cc73802.md
@@ -2,55 +2,41 @@ Often the best way to troubleshoot failures and bugs in your pipelines is to
 SSH into a job and inspect log files, running processes, and directory paths.
 Semaphore 2.0 gives you the option to access all running jobs via SSH, to
 restart your jobs in debug mode, or to start on-demand virtual machines to
-explore the build environment.
+explore the CI/CD environment.
 
 Before you begin, you'll need to [install the Semaphore CLI][install-cli].
 
-- [Setting Up Your SSH Key](#setting-up-your-ssh-key)
-- [Exploring the build environment](#exploring-the-build-environment)
-- [Inspecting the state of a running job](#inspecting-the-state-of-a-running-job)
 - [Restarting a job in debug mode](#restarting-a-job-in-debug-mode)
+- [Inspecting the state of a running job](#inspecting-the-state-of-a-running-job)
 - [Port forwarding your web server and debug UI issues](#port-forwarding-your-web-server-and-debug-ui-issues)
 - [Stopping a debug session](#stopping-a-debug-session)
 - [See also](#see-also)
 
-## Setting Up Your SSH Key
-
-You'll need to set your debug SSH key before continuing. You can use
-the same key you use for GitHub. Here's an example:
-
-``` bash
-sem config set debug.PublicSshKey "$(curl https://github.com/YOUR_USERNAME.keys)"
-```
-
-Replace `YOUR_USERNAME` with your GitHub username.
-
-Or you can use the first key in your SSH agent:
-
-``` bash
-sem config set debug.PublicSshKey "$(ssh-add -L | head -n 1)"
-```
-
-## Exploring the build environment
+## Restarting a job in debug mode
 
 Setting up a pipeline can be challenging if you are not familiar with the
 software stack installed in Semaphore 2.0 virtual machines. Starting a debug
-session for your project is a great place to start exploring.
+session for your job is a great place to start exploring.
 
-To start a debug session for your project, run:
+To start a debug session for your job, run:
 
 ``` bash
-sem debug project [name-of-your-project]
+sem debug job [job-id]
 ```
 
-The above command will start a virtual machine connected with your git
-repository and attach you to it via an SSH session.
+This will start a new interactive job based on the specification of the old one,
+export the same environment variables, inject the same secrets, and connect to
+the same git commit.
+
+Commands in the debug mode are not executed automatically, instead they are
+stored in `~/commands.sh`. This allows you to execute them step-by-step, and
+inspect the changes in the environment.
 
 By default, the duration of the SSH session is limited to one hour. To run
 longer debug sessions, pass the `duration` flag to the above command:
 
 ``` bash
-sem debug project [name-of-your-project] --duration 3h
+sem debug job [job-id] --duration 3h
 ```
 
 By default, a debug session does not include the contents of the GitHub
@@ -78,18 +64,6 @@ sem attach [job-id]
 
 Use `sem get jobs` to list running jobs.
 
-Access to the job's virtual machine is managed by the public SSH keys in the
-`.ssh/authorized_keys` file. To add your public key to the machine add the
-following command to your pipeline definition:
-
-``` bash
-echo '[your-public-key]' >> .ssh/authorized_keys
-```
-
-To manage multiple public keys for SSH access
-[store your public keys in a secret](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets).
-
-## Restarting a job in debug mode
 
 To find the root cause of a failed job, Semaphore allows you to restart your job
 in debug mode with the following command:
@@ -98,17 +72,9 @@ in debug mode with the following command:
 sem debug job [job-id]
 ```
 
-This will start a new interactive job based on the specification of the old one,
-export the same environment variables, inject the same secrets, and connect to
-the same git commit.
-
-Commands in the debug mode are not executed automatically, instead they are
-stored in `/home/semaphore/commands.sh`. This allows you to execute them
-step-by-step, and inspect the changes in the environment.
-
 ## Port forwarding your web server and debug UI issues
 
-Sometimes SSH access to your build environment is not enough to fully explore
+Sometimes SSH access to your CI/CD environment is not enough to fully explore
 the problem. For example, Selenium based tests will fail if the html elements
 are not visible on the screen when you are running the tests.
 
@@ -122,13 +88,14 @@ sem port-forward [job-id] 6000 3000
 
 The `http://localhost:6000` should now be accessible in your browser.
 
+Note: Port-Forwarding works only for Virtual Machine based CI/CD environments.
+
 ## Stopping a debug session
 
 The debug session will *automatically* end once you exit the SSH session. To
-manually stop a debug session, you can execute `sudo poweroff` or
-`sudo shutdown -r now` from the UNIX shell of the Semaphore VM or execute
-`sem stop job [job-id]` from your local machine. You can find the Job ID of
-your debug job using the `sem get jobs` command.
+manually stop a debug session execute `sem stop job [job-id]` from your local
+machine. You can find the Job ID of your debug job using the `sem get jobs`
+command.
 
 ## See also
 


### PR DESCRIPTION
New features in Sem CLI v0.13.0:

- SSH sessions (debug job, debug project) work without configuring the CLI with an SSH key
- Customers can attach to any Job without the need to inject public keys into the job
- Debugging and Attaching works for Docker based CI/CD environments

---

Updates in the docs:

- Sections about configuring SSH keys have been removed
- `sem debug job` is the primary way to debug, previously it was `sem debug project`. This update was decided during a sync with @markoa. Reasoning is that Semaphore 2.0 now automatically creates you an initial pipeline so you always have a job to debug.
- Added notes that port-forwarding works only for VM based jobs. We don't have a workaround for Docker based CI/CD yet.
- Updated "build environment" to "CI/CD environment in several places"