### PR TITLE
Fail-Fast

### DIFF
--- a/fail-fast.md
+++ b/fail-fast.md
@@ -1,0 +1,152 @@
+There are two strategies for running CI tests. A developer either wants to get
+a comprehensive report on all failures in a test suite or to get a fast
+feedback from the system and fail everything as soon as one of the jobs fails.
+
+Semaphore runs all the jobs and prepares a comprehensive report for
+your pipeline by default. By setting a Fail-Fast strategy in your pipelines
+you can control this policy and get a fast response for your pipelines.
+
+One out of two Fail-Fast strategies can be used:
+
+- A 'stop' strategy that stops everything in your pipeline as soon as a failure
+  is detected.
+
+- A 'cancel' strategy that stops only the jobs and blocks in your pipeline that
+  haven't yet started. This option is ideal if you don't want to stop an already
+  started test execution.
+
+[Stopping all jobs in a pipeline on the first failure](#stopping-all-jobs-in-a-pipeline-on-first-failure)
+[Stopping all jobs in a pipeline on the first failure on non-master branches](stopping-all-jobs-in-a-pipeline-on-the-first-failure-on-non-master-branches)
+[The difference between Stop and Cancel Fail-Fast strategies](#the-difference-between-stop-and-cancel-fail-fast-strategies)
+[See also](#see-also)
+
+## Stopping all jobs in a pipeline on first failure
+
+To stop all the jobs in a pipeline on the first failure, set a fail-fast stop
+policy in your pipeline YAML files.
+
+``` yaml
+version: v1.0
+name: Tests
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+fail_fast:
+  stop:
+    when: "true"  # enable strategy for branches, tags, and pull-requests
+
+blocks:
+  - name: Unit Tests
+    task:
+      jobs:
+      - name: "Unit Tests 1/2"
+        commands:
+          - make test PARTITION=1
+
+      - name: "Unit Tests 2/2"
+        commands:
+          - make test PARTITION=2
+```
+
+If 'Unit Test 1/2' fails in the above pipeline, the 'Unit Test 2/2' will be
+stopped.
+
+## Stopping all jobs in a pipeline on the first failure on non-master branches
+
+Often the fail-fast behavior is ideal for feature branches during development,
+but it is not ideal for the master branch of your project where a comprehensive
+report is better suited.
+
+By changing the `when` condition to `branch != 'master'`, we can set a policy
+that activates fail-fast only for non-master branches.
+
+``` yaml
+version: v1.0
+name: Tests
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+fail_fast:
+  stop:
+    when: "branch != 'master'"
+
+blocks:
+  - name: Unit Tests
+    task:
+      jobs:
+      - name: "Unit Tests 1/2"
+        commands:
+          - make test PARTITION=1
+
+      - name: "Unit Tests 2/2"
+        commands:
+          - make test PARTITION=2
+```
+
+## The difference between Stop and Cancel Fail-Fast strategies
+
+Sometimes it is not desirable to stop everything in a pipeline. Instead, we
+would like to allow already running jobs and blocks to finish, but prevent new
+ones from starting.
+
+For these scenarios, the 'cancel' strategy can be configured for your pipelines.
+
+``` yaml
+version: v1.0
+name: Tests
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+fail_fast:
+  cancel:
+    when: "branch != 'master'"
+
+blocks:
+  - name: Linter
+    dependencies: []
+    task:
+      jobs:
+      - name: "Linter"
+        commands:
+          - make lint
+
+  - name: Security Scan
+    dependencies: ["Linter"]
+    task:
+      jobs:
+      - name: "Security"
+        commands:
+          - make scan-for-vulnerabilities
+
+  - name: Unit Tests
+    dependencies: []
+    task:
+      jobs:
+      - name: "Unit Tests 1"
+        commands:
+          - make test
+
+  - name: Integration Tests
+    dependencies: ["Unit Tests"]
+    task:
+      jobs:
+      - name: "Unit Tests 1"
+        commands:
+          - make test
+```
+
+In the above scenario, if linting fails, but the unit tests have already started,
+we will not break them in the middle of the execution.
+
+The Security Scan and Integration Tests will be canceled.
+
+# See also
+
+- [Fail-Fast pipeline YAML property](https://docs.semaphoreci.com/article/50-pipeline-yaml#fail\_fast)
+- [Defining 'when' conditions](https://docs.semaphoreci.com/article/142-conditions-reference)

--- a/fail-fast_5d39b0120428634786756a14.md
+++ b/fail-fast_5d39b0120428634786756a14.md
@@ -1,10 +1,10 @@
 There are two strategies for running CI tests. A developer either wants to get
-a comprehensive report on all failures in a test suite or to get a fast
+a comprehensive report on all failures in a test suite or to get fast
 feedback from the system and fail everything as soon as one of the jobs fails.
 
 Semaphore runs all the jobs and prepares a comprehensive report for
 your pipeline by default. By setting a Fail-Fast strategy in your pipelines
-you can control this policy and get a fast response for your pipelines.
+you can control this policy and get fast response for your pipelines.
 
 One out of two Fail-Fast strategies can be used:
 
@@ -20,7 +20,7 @@ One out of two Fail-Fast strategies can be used:
 [The difference between Stop and Cancel Fail-Fast strategies](#the-difference-between-stop-and-cancel-fail-fast-strategies)
 [See also](#see-also)
 
-## Stopping all jobs in a pipeline on first failure
+## Stopping all jobs in a pipeline on the first failure
 
 To stop all the jobs in a pipeline on the first failure, set a fail-fast stop
 policy in your pipeline YAML files.

--- a/fail-fast_5d39b0120428634786756a14.md
+++ b/fail-fast_5d39b0120428634786756a14.md
@@ -1,12 +1,9 @@
-There are two strategies for running CI tests. A developer either wants to get
-a comprehensive report on all failures in a test suite or to get fast
-feedback from the system and fail everything as soon as one of the jobs fails.
+On Semaphore, a fail-fast strategy means that you get instant feedback when a
+job fails. All the running jobs of a pipeline are stopped as soon as one of the
+jobs fails. This means that you don't need to wait for all the other jobs to
+finish in order to get feedback.
 
-Semaphore runs all the jobs and prepares a comprehensive report for
-your pipeline by default. By setting a Fail-Fast strategy in your pipelines
-you can control this policy and get fast response for your pipelines.
-
-One out of two Fail-Fast strategies can be used:
+There are two fail-fast strategies:
 
 - A 'stop' strategy that stops everything in your pipeline as soon as a failure
   is detected.
@@ -17,7 +14,7 @@ One out of two Fail-Fast strategies can be used:
 
 [Stopping all jobs in a pipeline on the first failure](#stopping-all-jobs-in-a-pipeline-on-first-failure)
 [Stopping all jobs in a pipeline on the first failure on non-master branches](stopping-all-jobs-in-a-pipeline-on-the-first-failure-on-non-master-branches)
-[The difference between Stop and Cancel Fail-Fast strategies](#the-difference-between-stop-and-cancel-fail-fast-strategies)
+[Canceling all jobs in a pipeline on the first failure](#canceling-all-jobs-in-a-pipeline-on-the-first-failure)
 [See also](#see-also)
 
 ## Stopping all jobs in a pipeline on the first failure
@@ -87,7 +84,7 @@ blocks:
           - make test PARTITION=2
 ```
 
-## The difference between Stop and Cancel Fail-Fast strategies
+## Canceling all jobs in a pipeline on the first failure
 
 Sometimes it is not desirable to stop everything in a pipeline. Instead, we
 would like to allow already running jobs and blocks to finish, but prevent new

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -350,42 +350,26 @@ However, as blocks are currently executed sequentially, the
 
 ## fail_fast
 
-The `fail_fast` property enables you to set the desired policy for the behavior
-of other blocks when one of them fails.
+The `fail_fast` property enables you to set a policy for a pipeline when one of
+its jobs fail.
 
 It can have two subproperties, `stop` and `cancel`.
 
-At least one of them is required.
-
-If both are set, `stop` will be evaluated first.
+At least one of them is required. If both are set, `stop` will be evaluated first.
 
 Both `stop` and `cancel` properties require a condition defined with a `when`,
 following the [Conditions DSL][conditions-reference].
 
-If this condition is fulfilled for a given pipeline execution, an appropriate
-`fail fast` policy will be set for blocks of that pipeline.
+If this condition is fulfilled for a given pipeline execution, the appropriate
+`fail fast` policy is activated.
 
-If all blocks are run sequentially, `fail fast` policy is not necessary because
-if one block fails, the ones in a sequence after it won't be started and the
-whole pipeline will fail immediately.
+If a `stop` policy is set, all running jobs will be stopped and all pending
+ones will be canceled as soon as possible when one job fails.
 
-However, if you have blocks in your pipeline running in parallel (this can be
-achieved by setting [dependencies](#dependencies-in-blocks) property for each
-block), when one block fails, others which do not directly depend on it will
-continue to execute and use time and resources even though the whole pipeline
-can be considered to have failed.
-
-To optimize this, you can choose to set either `cancel` or `stop` fail fast
-policy.
-
-If a `cancel` policy is set, when one block fails the blocks which have not
-yet started executing will be canceled, but already running blocks will be
+If a `cancel` policy is set, when one job fails, the blocks and jobs which have
+not yet started executing will be canceled, but already running ones will be
 allowed to finish executing. This will provide you with more data for debugging
 without using additional resources.
-
-If a `stop` policy is set, all running blocks will be stopped and all pending
-ones will be canceled as soon as possible when one block fails.
-
 
 ### An example for setting fail fast stop policy
 

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -5,6 +5,7 @@
 - [agent](#agent)
   - [A Preface example](#a-preface-example)
 - [execution\_time\_limit](#execution_time_limit)
+- [fail\_fast](#fail_fast)
 - [Blocks](#blocks)
   - [name](#name-in-blocks)
   - [dependencies](#dependencies-in-blocks)
@@ -346,6 +347,92 @@ hours, which is the value of the `pipeline` scope `execution_time_limit` propert
 However, as blocks are currently executed sequentially, the
 `Building executable` block should finish in 5 hours minus the time it took the
 `Creating Docker Image` block to finish.
+
+## fail_fast
+
+The `fail_fast` property enables you to set a desired policy for behavior of
+other blocks when one of them fails.
+
+If all blocks are run sequentially, this is not necessary because if one block
+fails, the ones in a sequence after it won't be started and whole pipeline will
+fail immediately.
+
+However, if you have blocks in your pipeline running in parallel (this can be
+achieved by setting [dependencies](#dependencies-in-blocks) property for each
+block), when one block fails, others which do not directly depend on it will
+continue to execute and use time and resources even though whole pipeline will
+eventually fail.
+
+To optimize this, you can choose to set either `cancel` or `stop` fail_fast
+policy.
+
+If `cancel` policy is set, when one block fails the blocks which have not
+yet started executing will be canceled, but already running blocks will be
+allowed to finish executing. This will provide you with more data for debugging
+without occupying any more resources than what was occupied in a first place.
+
+If `stop` policy is set, all running blocks will be stopped and all pending ones
+will be canceled as soon as possible when one block fails.
+
+The `fail_fast` property can have two sub properties, `stop` and `cancel`.
+
+At least one of them is required and if both are stated, `stop` will be
+evaluated first.
+
+Both `stop` and `cancel` properties have only one required property, and that is
+`when` property which holds condition written in
+[Conditions DSL][conditions-reference].
+
+If this condition is fulfilled for given pipeline execution, appropriate
+`fail_fast` policy will be set for blocks of that pipeline.
+
+### An example for setting fail_fast policy
+
+In the following example blocks A and B will start immediately and block C will
+wait for block B to be finished.
+
+After 10 seconds when Block A fails, if pipeline was initiated from non-master
+branch, fail_fast `stop` policy will be applied and Block B will be stopped and
+Block C will be canceled.
+
+``` yaml
+version: v1.0
+name: Setting fail_fast stop policy
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+fail_fast:
+  stop:
+    when: "branch != 'master'"
+
+blocks:
+  - name: Block A
+    dependencies: []
+    task:
+      jobs:
+      - name: Job A
+        commands:
+          - sleep 10
+          - exit 127
+      - name: Block B
+        dependencies: []
+        task:
+          jobs:
+          - name: Job B
+            commands:
+              - sleep 60
+      - name: Block C
+        dependencies: [Block B]
+        task:
+          jobs:
+          - name: Job C
+            commands:
+              - sleep 60
+```
+
+More examples of conditions for frequent use cases can be found
+[here][when-repo-fail_fast-exemples].
 
 ## Blocks
 
@@ -1478,3 +1565,4 @@ YAML parser, which is not a Semaphore 2.0 feature but the way YAML files work.
 [macos-mojave]: https://docs.semaphoreci.com/article/120-macos-mojave-image
 [conditions-reference]:https://docs.semaphoreci.com/article/142-conditions-reference
 [when-repo-skip-exemples]: https://github.com/renderedtext/when#skip-block-exection
+[when-repo-fail_fast-exemples]: https://github.com/renderedtext/when#fail-fast

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -386,7 +386,7 @@ Both `stop` and `cancel` properties have only one required property, and that is
 If this condition is fulfilled for given pipeline execution, appropriate
 `fail_fast` policy will be set for blocks of that pipeline.
 
-### An example for setting fail_fast policy
+### An example for setting fail_fast stop policy
 
 In the following example blocks A and B will start immediately and block C will
 wait for block B to be finished.
@@ -414,7 +414,54 @@ blocks:
       - name: Job A
         commands:
           - sleep 10
-          - exit 127
+          - failing command
+      - name: Block B
+        dependencies: []
+        task:
+          jobs:
+          - name: Job B
+            commands:
+              - sleep 60
+      - name: Block C
+        dependencies: [Block B]
+        task:
+          jobs:
+          - name: Job C
+            commands:
+              - sleep 60
+```
+
+### An example for setting fail_fast cancel policy
+
+In the following example blocks A and B will start immediately and block C will
+wait for block B to be finished.
+
+After 10 seconds when Block A fails, if pipeline was initiated from non-master
+branch, fail_fast `cancel` policy will be applied.
+
+When this policy is applied, Block C will be canceled since it is not executing
+at that moment, but Block B will be allowed to finish its execution.
+
+``` yaml
+version: v1.0
+name: Setting fail_fast cancel policy
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+fail_fast:
+  cancel:
+    when: "branch != 'master'"
+
+blocks:
+  - name: Block A
+    dependencies: []
+    task:
+      jobs:
+      - name: Job A
+        commands:
+          - sleep 10
+          - failing command
       - name: Block B
         dependencies: []
         task:

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -350,24 +350,24 @@ However, as blocks are currently executed sequentially, the
 
 ## fail_fast
 
-The `fail_fast` property enables you to set a desired policy for behavior of
-other blocks when one of them fails.
+The `fail_fast` property enables you to set the desired policy for the behavior
+of other blocks when one of them fails.
 
-It can have two sub properties, `stop` and `cancel`.
+It can have two subproperties, `stop` and `cancel`.
 
-At least one of them is required and if both are stated, `stop` will be
-evaluated first.
+At least one of them is required.
 
-Both `stop` and `cancel` properties have only one required property, and that is
-`when` property which defines a condition using the
-[Conditions DSL][conditions-reference].
+If both are set, `stop` will be evaluated first.
 
-If this condition is fulfilled for given pipeline execution, appropriate
-`fail_fast` policy will be set for blocks of that pipeline.
+Both `stop` and `cancel` properties require a condition defined with a `when`,
+following the [Conditions DSL][conditions-reference].
 
-If all blocks are run sequentially, `fail_fast` policy is not necessary because
-if one block fails, the ones in a sequence after it won't be started and whole
-pipeline will fail immediately.
+If this condition is fulfilled for a given pipeline execution, an appropriate
+`fail fast` policy will be set for blocks of that pipeline.
+
+If all blocks are run sequentially, `fail fast` policy is not necessary because
+if one block fails, the ones in a sequence after it won't be started and the
+whole pipeline will fail immediately.
 
 However, if you have blocks in your pipeline running in parallel (this can be
 achieved by setting [dependencies](#dependencies-in-blocks) property for each
@@ -375,32 +375,32 @@ block), when one block fails, others which do not directly depend on it will
 continue to execute and use time and resources even though the whole pipeline
 can be considered to have failed.
 
-To optimize this, you can choose to set either `cancel` or `stop` fail_fast
+To optimize this, you can choose to set either `cancel` or `stop` fail fast
 policy.
 
-If `cancel` policy is set, when one block fails the blocks which have not
+If a `cancel` policy is set, when one block fails the blocks which have not
 yet started executing will be canceled, but already running blocks will be
 allowed to finish executing. This will provide you with more data for debugging
-without occupying any more resources than what was occupied in a first place.
+without using additional resources.
 
-If `stop` policy is set, all running blocks will be stopped and all pending ones
-will be canceled as soon as possible when one block fails.
+If a `stop` policy is set, all running blocks will be stopped and all pending
+ones will be canceled as soon as possible when one block fails.
 
 
-### An example for setting fail_fast stop policy
+### An example for setting fail fast stop policy
 
 In the following configuration, blocks A and B run in parallel. Block C runs
 after block B is finished.
 
 When Block A fails, if the workflow was initiated from a non-master branch, the
-fail_fast `stop` policy will be applied to:
+fail fast `stop` policy will be applied to:
 
 - Stop the block B
 - Cancel (ie. not run) the block C
 
 ``` yaml
 version: v1.0
-name: Setting fail_fast stop policy
+name: Setting fail fast stop policy
 agent:
   machine:
     type: e1-standard-2
@@ -434,20 +434,20 @@ blocks:
               - sleep 60
 ```
 
-### An example for setting fail_fast cancel policy
+### An example for setting fail fast cancel policy
 
 In the following configuration, blocks A and B run in parallel. Block C runs
 after block B is finished.
 
 When Block A fails, if the workflow was initiated from a non-master branch, the
-fail_fast `cancel` policy will be applied to:
+fail fast `cancel` policy will be applied to:
 
 - Let the block B finish
 - Cancel (ie. not run) the block C
 
 ``` yaml
 version: v1.0
-name: Setting fail_fast cancel policy
+name: Setting fail fast cancel policy
 agent:
   machine:
     type: e1-standard-2

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -353,15 +353,27 @@ However, as blocks are currently executed sequentially, the
 The `fail_fast` property enables you to set a desired policy for behavior of
 other blocks when one of them fails.
 
-If all blocks are run sequentially, this is not necessary because if one block
-fails, the ones in a sequence after it won't be started and whole pipeline will
-fail immediately.
+It can have two sub properties, `stop` and `cancel`.
+
+At least one of them is required and if both are stated, `stop` will be
+evaluated first.
+
+Both `stop` and `cancel` properties have only one required property, and that is
+`when` property which defines a condition using the
+[Conditions DSL][conditions-reference].
+
+If this condition is fulfilled for given pipeline execution, appropriate
+`fail_fast` policy will be set for blocks of that pipeline.
+
+If all blocks are run sequentially, `fail_fast` policy is not necessary because
+if one block fails, the ones in a sequence after it won't be started and whole
+pipeline will fail immediately.
 
 However, if you have blocks in your pipeline running in parallel (this can be
 achieved by setting [dependencies](#dependencies-in-blocks) property for each
 block), when one block fails, others which do not directly depend on it will
-continue to execute and use time and resources even though whole pipeline will
-eventually fail.
+continue to execute and use time and resources even though the whole pipeline
+can be considered to have failed.
 
 To optimize this, you can choose to set either `cancel` or `stop` fail_fast
 policy.
@@ -374,26 +386,17 @@ without occupying any more resources than what was occupied in a first place.
 If `stop` policy is set, all running blocks will be stopped and all pending ones
 will be canceled as soon as possible when one block fails.
 
-The `fail_fast` property can have two sub properties, `stop` and `cancel`.
-
-At least one of them is required and if both are stated, `stop` will be
-evaluated first.
-
-Both `stop` and `cancel` properties have only one required property, and that is
-`when` property which holds condition written in
-[Conditions DSL][conditions-reference].
-
-If this condition is fulfilled for given pipeline execution, appropriate
-`fail_fast` policy will be set for blocks of that pipeline.
 
 ### An example for setting fail_fast stop policy
 
-In the following example blocks A and B will start immediately and block C will
-wait for block B to be finished.
+In the following configuration, blocks A and B run in parallel. Block C runs
+after block B is finished.
 
-After 10 seconds when Block A fails, if pipeline was initiated from non-master
-branch, fail_fast `stop` policy will be applied and Block B will be stopped and
-Block C will be canceled.
+When Block A fails, if the workflow was initiated from a non-master branch, the
+fail_fast `stop` policy will be applied to:
+
+- Stop the block B
+- Cancel (ie. not run) the block C
 
 ``` yaml
 version: v1.0
@@ -423,7 +426,7 @@ blocks:
             commands:
               - sleep 60
       - name: Block C
-        dependencies: [Block B]
+        dependencies: ["Block B"]
         task:
           jobs:
           - name: Job C
@@ -433,14 +436,14 @@ blocks:
 
 ### An example for setting fail_fast cancel policy
 
-In the following example blocks A and B will start immediately and block C will
-wait for block B to be finished.
+In the following configuration, blocks A and B run in parallel. Block C runs
+after block B is finished.
 
-After 10 seconds when Block A fails, if pipeline was initiated from non-master
-branch, fail_fast `cancel` policy will be applied.
+When Block A fails, if the workflow was initiated from a non-master branch, the
+fail_fast `cancel` policy will be applied to:
 
-When this policy is applied, Block C will be canceled since it is not executing
-at that moment, but Block B will be allowed to finish its execution.
+- Let the block B finish
+- Cancel (ie. not run) the block C
 
 ``` yaml
 version: v1.0
@@ -470,16 +473,13 @@ blocks:
             commands:
               - sleep 60
       - name: Block C
-        dependencies: [Block B]
+        dependencies: ["Block B"]
         task:
           jobs:
           - name: Job C
             commands:
               - sleep 60
 ```
-
-More examples of conditions for frequent use cases can be found
-[here][when-repo-fail_fast-exemples].
 
 ## Blocks
 
@@ -1612,4 +1612,3 @@ YAML parser, which is not a Semaphore 2.0 feature but the way YAML files work.
 [macos-mojave]: https://docs.semaphoreci.com/article/120-macos-mojave-image
 [conditions-reference]:https://docs.semaphoreci.com/article/142-conditions-reference
 [when-repo-skip-exemples]: https://github.com/renderedtext/when#skip-block-exection
-[when-repo-fail_fast-exemples]: https://github.com/renderedtext/when#fail-fast

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -353,7 +353,7 @@ However, as blocks are currently executed sequentially, the
 The `fail_fast` property enables you to set a policy for a pipeline when one of
 its jobs fail.
 
-It can have two subproperties, `stop` and `cancel`.
+It can have two sub-properties, `stop` and `cancel`.
 
 At least one of them is required. If both are set, `stop` will be evaluated first.
 
@@ -361,7 +361,7 @@ Both `stop` and `cancel` properties require a condition defined with a `when`,
 following the [Conditions DSL][conditions-reference].
 
 If this condition is fulfilled for a given pipeline execution, the appropriate
-`fail fast` policy is activated.
+fail-fast policy is activated.
 
 If a `stop` policy is set, all running jobs will be stopped and all pending
 ones will be canceled as soon as possible when one job fails.
@@ -371,7 +371,7 @@ not yet started executing will be canceled, but already running ones will be
 allowed to finish executing. This will provide you with more data for debugging
 without using additional resources.
 
-### An example for setting fail fast stop policy
+### An example of setting fail-fast stop policy
 
 In the following configuration, blocks A and B run in parallel. Block C runs
 after block B is finished.
@@ -379,8 +379,8 @@ after block B is finished.
 When Block A fails, if the workflow was initiated from a non-master branch, the
 fail fast `stop` policy will be applied to:
 
-- Stop the block B
-- Cancel (ie. not run) the block C
+- Stop block B
+- Cancel (ie. not run) block C
 
 ``` yaml
 version: v1.0
@@ -389,6 +389,7 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+
 fail_fast:
   stop:
     when: "branch != 'master'"
@@ -418,7 +419,7 @@ blocks:
               - sleep 60
 ```
 
-### An example for setting fail fast cancel policy
+### An example of setting fail-fast cancel policy
 
 In the following configuration, blocks A and B run in parallel. Block C runs
 after block B is finished.
@@ -426,8 +427,8 @@ after block B is finished.
 When Block A fails, if the workflow was initiated from a non-master branch, the
 fail fast `cancel` policy will be applied to:
 
-- Let the block B finish
-- Cancel (ie. not run) the block C
+- Let block B finish
+- Cancel (ie. not run) block C
 
 ``` yaml
 version: v1.0
@@ -436,6 +437,7 @@ agent:
   machine:
     type: e1-standard-2
     os_image: ubuntu1804
+
 fail_fast:
   cancel:
     when: "branch != 'master'"


### PR DESCRIPTION
Here are docs for `fail_fast` on pipeline level. 

It is a bit more detailed than most of other topics in reference because `fail_fast` is not that wildly known term and I think it has to be explained a bit. 

Also, once job level `fail_fast` is finished we should add note here that it will be automatically set when you set pipeline level one.