### PR TITLE
fix indentation on netlify use case

### DIFF
--- a/netlify-continuous-deployment_5cebfc272c7d3a32d2a4d5cf.md
+++ b/netlify-continuous-deployment_5cebfc272c7d3a32d2a4d5cf.md
@@ -102,19 +102,19 @@ To obtain your Netlify credentials:
     command depends on whether you are updating an existing site or
     creating a new one. If you are:
     
-      - Creating a new site:
-        
-        ``` bash
-        $ cd /your/project/path
-        $ netlify init
-        ```
+- Creating a new site:
     
-      - Updating a previously existing site:
-        
-        ``` bash
-        $ cd /your/project/path
-        $ netlify link
-        ```
+    ``` bash
+    $ cd /your/project/path
+    $ netlify init
+    ```
+
+- Updating a previously existing site:
+    
+    ``` bash
+    $ cd /your/project/path
+    $ netlify link
+    ```
 
 ### Store credentials on Semaphore
 


### PR DESCRIPTION
On the Semaphore doc page: at step 3 "Link your project's directory with the Netlify site...." you can see the code fences. This PR removes some indentation to fix the issue.