### PR TITLE
Add auto-cancel in pipeline yml reference docs

### DIFF
--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -6,6 +6,7 @@
   - [A Preface example](#a-preface-example)
 - [execution\_time\_limit](#execution_time_limit)
 - [fail\_fast](#fail_fast)
+- [auto\_cancel](#auto_cancel)
 - [Blocks](#blocks)
   - [name](#name-in-blocks)
   - [dependencies](#dependencies-in-blocks)
@@ -465,6 +466,90 @@ blocks:
           - name: Job C
             commands:
               - sleep 60
+```
+
+## auto_cancel
+
+The `auto_cancel` property enables you to set a strategy for auto-canceling other
+pipelines in a queue when a new one appears.
+
+It can have two sub-properties, `running` and `queued`.
+
+At least one of them is required. If both are set, `running` will be evaluated
+first.
+
+Both `running` and `queued` properties require a condition defined with a `when`,
+following the [Conditions DSL][conditions-reference].
+
+If this condition is fulfilled for a given pipeline execution, the appropriate
+auto-cancel strategy will be implemented.
+
+If a `running` auto-cancel strategy is set, the newest pipeline in a queue will:
+- cancel all queued pipelines in a queue before self
+- stop any running pipeline in a queue before self
+
+This will make new pipelines start running as soon as possible while still making
+sure that pipelines from the same queue are not run in parallel.
+
+If a `queued` auto-cancel strategy is set, the newest pipeline in a queue will:
+- cancel all queued pipelines in a queue before self
+- wait for any running pipeline in a queue before self to finish
+
+This way you will always get results for anything that was already using resources
+but the new pipelines will be delayed a bit more in a queue.
+
+### An example of setting auto-cancel running strategy
+
+In the following configuration, all pipelines initiated from a non-master branch
+will run immediately after auto stopping everything else in front of them in the
+queue.
+
+``` yaml
+version: v1.0
+name: Setting auto-cancel running strategy
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+auto_cancel:
+  running:
+    when: "branch != 'master'"
+
+blocks:
+  - name: Unit tests
+    task:
+      jobs:
+      - name: Unit tests job
+        commands:
+          - echo Running unit test
+```
+
+### An example of setting auto-cancel queued strategy
+
+In the following configuration, all pipelines initiated from a non-master branch
+will cancel any queued pipelines and wait for running one to finish before starting
+to run.
+
+``` yaml
+version: v1.0
+name: Setting auto-cancel queued strategy
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+auto_cancel:
+  queued:
+    when: "branch != 'master'"
+
+blocks:
+  - name: Unit tests
+    task:
+      jobs:
+      - name: Unit tests job
+        commands:
+          - echo Running unit test
 ```
 
 ## Blocks


### PR DESCRIPTION
Here are docs about the auto-cancel feature in the pipeline yml reference page.

This is a bare minimum for the feature to be considered as done, and it might be a good idea to also add a separate page in the `Use Cases` section. 
If you agree with this, I will add it in a separate PR.