### PR TITLE
pipeline-reference: Add global_job_config_docs

### DIFF
--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -596,9 +596,22 @@ global_job_config:
     - name: TEST_ENV_VAR
       value: test_value
 blocks:
-  - task:
+  - name: Linter
+    task:
       jobs:
-        - name: Job 1
+        - name: Linter
+          commands:
+            - echo $TEST_ENV_VAR
+  - name: Unit tests
+    task:
+      jobs:
+        - name: Unit testing
+          commands:
+            - echo $TEST_ENV_VAR
+  - name: Integration Tests
+    task:
+      jobs:
+        - name: Integration testing
           commands:
             - echo $TEST_ENV_VAR
 ```

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -7,6 +7,7 @@
 - [execution\_time\_limit](#execution_time_limit)
 - [fail\_fast](#fail_fast)
 - [auto\_cancel](#auto_cancel)
+- [global\_job\_config](#global_job_config)
 - [Blocks](#blocks)
   - [name](#name-in-blocks)
   - [dependencies](#dependencies-in-blocks)
@@ -550,6 +551,56 @@ blocks:
       - name: Unit tests job
         commands:
           - echo Running unit test
+```
+
+## global_job_config
+
+The `global_job_config` property enables you to choose a set of configuration
+that is shared across the whole pipeline and define it in one place instead of
+having to repeat it in every task separately.
+
+It can contain any of these properties:
+- [prologue](#prologue)
+- [epilogue](#epilogue)
+- [secrets](#secrets)
+- [env_vars](#env_vars)
+
+The defined configuration values have completely the same syntax as the ones
+defined on a task level and are applied to all the tasks and jobs in a pipeline.
+
+In the case of `prologue` and `env_vars` the global values, ones from
+`global_job_config`, are exported first, and after them, the ones defined on a
+task level.
+This allows overriding global values for the specific task if there is a need for
+that.
+
+In the case of `epilogue`, the order of exporting is reversed, so, for example,
+one can firstly perform specific cleanup commands before the global ones.
+
+The `secrets` are just merged since ordering plays no role there.
+
+### An example of using global_job_config property
+
+``` yaml
+version: "v1.0"
+name: An example of using global_job_config
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+global_job_config:
+  prologue:
+    commands:
+      - checkout
+  env_vars:
+    - name: TEST_ENV_VAR
+      value: test_value
+blocks:
+  - task:
+      jobs:
+        - name: Job 1
+          commands:
+            - echo $TEST_ENV_VAR
 ```
 
 ## Blocks


### PR DESCRIPTION
Here are the docs for `global_job_cnofig`, I remembered having it almost defined [here](https://github.com/semaphoreci/docs/issues/447) and that sped up the process.

Closes #447 