### PR TITLE
pipeline-reference: Fix rendering problems for global_job_config

### DIFF
--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -553,13 +553,14 @@ blocks:
           - echo Running unit test
 ```
 
-## global_job_config
+## global\_job\_config
 
 The `global_job_config` property enables you to choose a set of configuration
 that is shared across the whole pipeline and define it in one place instead of
 having to repeat it in every task separately.
 
 It can contain any of these properties:
+
 - [prologue](#prologue)
 - [epilogue](#epilogue)
 - [secrets](#secrets)
@@ -579,7 +580,7 @@ one can firstly perform specific cleanup commands before the global ones.
 
 The `secrets` are just merged since ordering plays no role there.
 
-### An example of using global_job_config property
+### An example of using global\_job\_config property
 
 ``` yaml
 version: "v1.0"


### PR DESCRIPTION
Fixes the problem with rendering headlines and lists in the HelpScout document. 
They were not present on Github rendered page, so there is no way to check without merging the changes.