### PR TITLE
[Cache] Add corrupted archives troubleshooting steps

### DIFF
--- a/caching_5d289bae042863478674d6cd.md
+++ b/caching_5d289bae042863478674d6cd.md
@@ -15,6 +15,7 @@ can be a single file or a directory.
 - [Basic Usage](#basic-usage)
 - [Advanced Usage](#advanced-usage)
 - [Requirements](#requirements)
+- [Troubleshooting](#troubleshooting)
 
 ### Basic usage
 
@@ -199,7 +200,6 @@ Examples:
 $ checksum package.json 3dc6f33834092c93d26b71f9a35e4bb3
 ```
 
-
 ### Requirements
 
 The `cache` tool depends on the following environment variables
@@ -215,3 +215,63 @@ which are automatically set in every job environment:
   (`/home/semaphore/.ssh/semaphore_cache_key`).
 
 Additionally, `cache` uses `tar` to archive the specified directory or file.
+
+## Troubleshooting
+
+### `cache restore` restores an archive with the corrupted archive message
+
+If the `cache restore` output log includes lines similar to the following:
+
+```bash
+$ cache restore gems-$SEMAPHORE_GIT_SHA
+==> HIT: gems-c964fbeac09ef1fad45c2b10c849a4e6b23763b4, using key gems-c964fbeac09ef1fad45c2b10c849a4e6b23763b4
+gzip: stdin: unexpected end of file
+tar: Unexpected EOF in archive
+tar: Unexpected EOF in archive
+tar: Error is not recoverable: exiting now
+Restored: vendor/bundle
+```
+
+You can make sure that only one job is creating an archive under the specific cache key.
+
+Cache archives usually get corrupted when `cache store` is added to the [prologue command sequence][prologue commands],
+resulting with its execution for all jobs in the related block.
+
+To address the issue, structure Semaphore yml so that `cache store` for an archive
+is executed in one job and `cache restore` in the succeeding jobs.
+
+Example YML:
+
+```
+blocks:
+  - name: Cache dependencies
+    task:
+      jobs:
+        - name: Cache gems
+          commands:
+            - checkout
+            - cache restore bundle-gems-$(checksum Gemfile.lock)
+            - bundle install --deployment --path vendor/bundle
+            - cache store bundle-gems-$(checksum Gemfile.lock) vendor/bundle
+
+  - name: Tests
+    task:
+      prologue:
+        commands:
+          - checkout
+          - cache restore bundle-gems-$(checksum Gemfile.lock)
+          - bundle install --deployment --path vendor/bundle
+      jobs:
+        - name: RSpec 0
+          commands:
+        - name: RSpec 1
+          commands:
+        - name: RSpec 1
+          commands:
+```
+
+__Note:__ Launch a [debugging session][debug session] to clear corrupted archives for your project
+by executing `cache clear` or `cache delete <key>`.
+
+[debug session]: https://docs.semaphoreci.com/article/75-debugging-with-ssh-access
+[prologue commands]: https://docs.semaphoreci.com/article/50-pipeline-yaml


### PR DESCRIPTION
New Semaphore users often run into the problem when `cache restore` restores a corrupted archive. 

```
tar: Unexpected EOF in archive
tar: Unexpected EOF in archive
```

In general, archives get corrupted when these are being created. More specifically, usually this is the case when different jobs are simultaneously creating an archive under the same cache key.

This PR addresses #303 
