### PR TITLE
Update ZEIT Now use case for zero config

### DIFF
--- a/zeit-now_5ccb11cd2c7d3a177d6e473a.md
+++ b/zeit-now_5ccb11cd2c7d3a177d6e473a.md
@@ -1,16 +1,20 @@
 This guide shows you how to use Semaphore to set up continuous integration and
-deployment to [Zeit Now](https://zeit.co).
+deployment to [ZEIT Now](https://zeit.co).
 
 ## Demo project
 
 Semaphore provides a demo project:
 
-- [Demo Zeit Now project on GitHub](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now)
+- [Demo ZEIT Now project on GitHub](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now)
 
-The demo consists of an API server that replies with a simple JSON
-payload. The project runs on [Node.js](https://nodejs.org). It uses
-[Express](http://expressjs.com/) for the web framework and
-[Jest](https://jestjs.io/) for testing.
+The demo deploys a serverless function that replies “Hello World!” to all HTTP
+requests.
+
+Testing serverless functions can be challenging. To emulate the cloud
+environment in Semaphore, the project uses a combination of
+[Node.js](https://nodejs.org), [Express](http://expressjs.com/),
+[Jest](https://jestjs.io/) and
+[Supertest](https://github.com/visionmedia/supertest).
 
 ## Overview of the pipelines
 
@@ -18,31 +22,35 @@ The pipeline performs the following tasks:
 
 - Install dependencies.
 - Run unit tests.
-- Continuously deploy master branch to production site.
+- Continuously deploy the master branch to the production site.
 
 On manual approval:
 
-- Deploy to staging site.
+- Deploy to the staging site.
 
-The `.semaphore` directory in the repository contains annotated pipeline configuration files.
+The complete CI/CD workflow looks like this:
 
-![CI+CD
-Pipelines for Zeit Now](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now/raw/master/images/semaphore-zeit-now-ci-cd.png)
+![CI+CD Pipelines for ZEIT Now](https://raw.githubusercontent.com/semaphoreci-demos/semaphore-demo-zeit-now/master/images/ci-pipeline.png)
 
 
-## Continuous integration pipeline
+### Continuous Integration Pipeline (CI)
+
+In the repository, the `.semaphore` directory contains the annotated pipeline configuration files.
+
+The CI pipeline takes place in 2 blocks:
+
+-   npm install and cache:
+    -   Downloads and installs the Node.js packages.
+    -   Builds the app and saves it to the cache.
+-   npm test:
+    -   Runs unit and coverage tests.
 
 ```yaml
-# Use the latest stable version of Semaphore 2.0 YML syntax:
 version: v1.0
-
-# Name your pipeline. In case you connect multiple pipelines with promotions,
-# the name will help you differentiate between, for example, a CI build phase
-# and delivery phases.
-name: Build and test Express.js app
+name: Build and test 
 
 # An agent defines the environment in which your code runs.
-# It is a combination of one of available machine types and operating
+# It is a combination of one of the available machine types and operating
 # system images.
 # See https://docs.semaphoreci.com/article/20-machine-types
 # and https://docs.semaphoreci.com/article/32-ubuntu-1804-image
@@ -61,24 +69,12 @@ blocks:
       jobs:
         - name: npm install and cache
           commands:
-            # Get the latest version of our source code from GitHub:
             - checkout
-
-            # Use the version of Node.js specified in .nvmrc.
-            # Semaphore provides nvm preinstalled.
             - nvm use
             - node --version
             - npm --version
-
-            # Restore dependencies from cache. This command will not fail in
-            # case of a cache miss. In case of a cache hit, npm install will
-            # run very fast.
-            # For more info on caching, see https://docs.semaphoreci.com/article/149-caching
             - cache restore
             - npm install
-
-            # Store the latest version of node modules in cache to reuse in
-            # further blocks:
             - cache store
 
   - name: Run tests
@@ -96,7 +92,7 @@ promotions:
   - name: Deploy to staging
     pipeline_file: deploy-staging.yml
 
-  # Automatically deploy to production on successful builds on master branch:
+  # Automatically deploy to production on successful builds on the master branch:
   - name: Deploy to production
     pipeline_file: deploy-production.yml
     auto_promote_on:
@@ -105,15 +101,6 @@ promotions:
           - master
 ```
 
-Just 2 blocks make the CI pipeline:
-
-![CI Pipeline](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now/raw/master/images/semaphore-zeit-now-ci.png)
-
--   npm install and cache:
-    -   Downloads and installs the Node.js packages.
-    -   Builds the app and saves it to the cache.
--   npm test:
-    -   Runs unit and coverage tests.
 
 Two
 [promotions](https://docs.semaphoreci.com/article/50-pipeline-yaml#promotions)
@@ -123,7 +110,9 @@ branch out of the CI pipeline:
     for the master branch.
 -   Deploy to staging: can be manually initiated from a Semaphore workflow on any branch.
 
-## Continuous deployment pipeline
+### Continuous Deployment Pipeline (CD)
+
+The CD pipeline consists of a block with a single job:
 
 ``` yaml
 version: v1.0
@@ -138,76 +127,58 @@ blocks:
       secrets:
         - name: now
       jobs:
-      - name: Deploy to Zeit Now
+      - name: Deploy to ZEIT Now
         commands:
           - checkout
           - nvm use
           - npm install now -g
-          - now --token $ZEIT_TOKEN --local-config production.json
+          - now --token $ZEIT_TOKEN -n semaphore-demo-zeit-now
+
 ```
 
-The deployment pipeline consists of one block:
+ZEIT Now is a cloud service for web services and serverless functions.
+Deployment is performed with the [Now
+CLI](https://zeit.co/docs/v2/getting-started/installation/#now-cli). No
+configuration file is required as long as the project files are located in
+these special directories:
 
-![CD Pipeline](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now/raw/master/images/semaphore-zeit-now-cd-production.png)
+- `public` for static files.
+- `api` or `pages/api` for serverless functions.
 
-### Node.js
+In addition, ZEIT Now can automatically build many [popular frameworks](https://zeit.co/docs/v2/build-step/#optimized-frameworks).
 
-Both
-[nvm](https://docs.semaphoreci.com/article/32-ubuntu-1804-image#javascript-via-node-js)
-and [npm](https://www.npmjs.com) are pre-installed on Semaphore's Ubuntu
-image. We can use the them to switch Node.js versions and install
-packages.
+Both staging and production pipelines are almost identical. They
+only differ on the app name, which maps to the final deployment URL like this:
 
-### Deployment
+- Production: `semaphore-demo-zeit-now.YOUR_USERNAME.now.sh`
+- Staging: `semaphore-demo-zeit-now-staging.YOUR_USERNAME.now.sh`
 
-Zeit Now is a cloud service for serverless websites
-and web applications. Deployment is performed with the
-[Now CLI](https://zeit.co/docs/v2/getting-started/installation/#now-cli)
-and a config file:
-
-``` javascript
-{
-  "version": 2,
-  "name": "semaphore-demo",
-  "builds": [
-      { "src": "**/*.js", "use": "@now/node" }
-  ]
-}
-```
-
-Both staging and production pipelines are practically identical. They
-only differ on the app `name`, which maps to the final URL:
-
--   Production: `semaphore-demo.USERNAME.now.sh`
--   Staging: `semaphore-demo-staging.USERNAME.now.sh`
-
-## Run the demo yourself
+## Run The Demo Yourself
 
 You can get started right away with Semaphore. Running and deploying the
 demo by yourself takes only a few minutes:
 
-### Get a Zeit token
+### Get a Token
 
-1.  Create a [Zeit](https://zeit.co) account.
+1.  Create a [ZEIT Now](https://zeit.co) account.
 2.  Open your account **Settings**
 3.  Go to the **Tokens** tab.
 4.  Click on the **Create** button.
 5.  Enter a name for the token, something descriptive like:
     semaphore-zeit-now
+6. Copy the generated token and keep it safe.
 
 ![Create Token](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now/raw/master/images/zeit-create-token.png)
 
-6. Copy the generated token and keep it safe.
-
 ### Create the pipeline on Semaphore
 
-Now add the token to Semaphore:
+Now, add the token to Semaphore:
 
 1.  Create an account for [Semaphore](https://semaphoreci.com).
 2.  On the left navigation bar, under **Configuration** click on
     **Secrets**.
 3.  Hit the **Create New Secret** button.
-4.  Create the secret as shown below. Copy the token obtained earlier.
+4.  Create the secret, as shown below. Copy the token obtained earlier.
 
 ![Create Secret](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now/raw/master/images/semaphore-create-secret.png)
 
@@ -222,19 +193,17 @@ To run the project on Semaphore:
 4.  Edit any file and do a push to GitHub, Semaphore starts
     automatically.
 
+Once the deployment is complete, the API service should be online. Browse the production URL:
 
-Once deployment is completed, the API service should be online. Browse the production URL:
-
-![API
-Service](https://github.com/semaphoreci-demos/semaphore-demo-zeit-now/raw/master/images/semaphore-demo-zeit-now-json.png)
-
+```bash
+$ curl -w "\n" https://semaphore-demo-zeit-now.YOUR_USERNAME.now.sh/api/hello
+Hello World!
+```
 ## See also
 
 -   [Semaphore guided
     tour](https://docs.semaphoreci.com/category/56-guided-tour)
 -   [Pipelines
     reference](https://docs.semaphoreci.com/article/50-pipeline-yaml)
--   [Environment variables and
-    secrets](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets)
--   [JavaScript and
-    Node.js](https://docs.semaphoreci.com/article/82-language-javascript-and-nodejs)
+-   [Environment variables and secrets](https://docs.semaphoreci.com/article/66-environment-variables-and-secrets)
+-   [JavaScript and Node.js](https://docs.semaphoreci.com/article/82-language-javascript-and-nodejs)

--- a/zeit-now_5ccb11cd2c7d3a177d6e473a.md
+++ b/zeit-now_5ccb11cd2c7d3a177d6e473a.md
@@ -35,7 +35,8 @@ The complete CI/CD workflow looks like this:
 
 ### Continuous Integration Pipeline (CI)
 
-In the repository, the `.semaphore` directory contains the annotated pipeline configuration files.
+In the repository, the `.semaphore` directory contains the annotated pipeline 
+configuration files.
 
 The CI pipeline takes place in 2 blocks:
 
@@ -102,13 +103,13 @@ promotions:
 ```
 
 
-Two
-[promotions](https://docs.semaphoreci.com/article/50-pipeline-yaml#promotions)
+Two [promotions](https://docs.semaphoreci.com/article/50-pipeline-yaml#promotions)
 branch out of the CI pipeline:
 
 -   Deploy to production: automatically started once all tests are green
     for the master branch.
--   Deploy to staging: can be manually initiated from a Semaphore workflow on any branch.
+-   Deploy to staging: can be manually initiated from a Semaphore workflow 
+    on any branch.
 
 ### Continuous Deployment Pipeline (CD)
 
@@ -145,7 +146,8 @@ these special directories:
 - `public` for static files.
 - `api` or `pages/api` for serverless functions.
 
-In addition, ZEIT Now can automatically build many [popular frameworks](https://zeit.co/docs/v2/build-step/#optimized-frameworks).
+In addition, ZEIT Now can automatically build many 
+[popular frameworks](https://zeit.co/docs/v2/build-step/#optimized-frameworks).
 
 Both staging and production pipelines are almost identical. They
 only differ on the app name, which maps to the final deployment URL like this:
@@ -193,7 +195,8 @@ To run the project on Semaphore:
 4.  Edit any file and do a push to GitHub, Semaphore starts
     automatically.
 
-Once the deployment is complete, the API service should be online. Browse the production URL:
+Once the deployment is complete, the API service should be online. 
+Browse the production URL:
 
 ```bash
 $ curl -w "\n" https://semaphore-demo-zeit-now.YOUR_USERNAME.now.sh/api/hello


### PR DESCRIPTION
The demo has been updated to take advantage of ZEIT Now new zero-config setups.
Hence, we need to update the use case accordingly.

- Updated workflow picture
- Removed now.json config
- Removed some unneeded paragraphs
- Removed some of the comment noise in the pipepelines

References:
https://zeit.co/blog/zero-config
https://zeit.co/guides/upgrade-to-zero-configuration/