### PR TITLE
Updated some outdated links to the 120-macos-mojave-image document

### DIFF
--- a/concepts_5bb90f3b042863158cc7220c.md
+++ b/concepts_5bb90f3b042863158cc7220c.md
@@ -75,5 +75,5 @@ you want it.
 [next]: https://docs.semaphoreci.com/article/64-customizing-your-pipeline
 [machine-types]: https://docs.semaphoreci.com/article/20-machine-types
 [ubuntu]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image
-[macos]: https://docs.semaphoreci.com/article/120-macos-mojave-image
+[macos]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image
 [docker-containers]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker

--- a/language-java_5bdc413b2c7d3a01757aba83.md
+++ b/language-java_5bdc413b2c7d3a01757aba83.md
@@ -119,7 +119,7 @@ blocks:
 [demo-project]: https://github.com/semaphoreci-demos/semaphore-demo-java-spring
 [ubuntu-java]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image#java-and-jvm-languages
 [ubuntu1804]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image
-[macos-java]: https://docs.semaphoreci.com/article/120-macos-mojave-image#java
+[macos-java]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image#java
 [docker-env]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker
 [sem-version]: https://docs.semaphoreci.com/article/131-sem-version-managing-language-version-on-linux
 [caching]: https://docs.semaphoreci.com/article/68-caching-dependencies

--- a/language-javascript-and-nodejs_5bdc260a2c7d3a01757ab9c3.md
+++ b/language-javascript-and-nodejs_5bdc260a2c7d3a01757ab9c3.md
@@ -178,6 +178,6 @@ for details on pre-installed browsers and testing tools on Semaphore.
 [tutorial]: https://docs.semaphoreci.com/article/121-nodejs-typescript-continuous-integration
 [demo-project]: https://github.com/semaphoreci-demos/semaphore-demo-javascript
 [ubuntu-javascript]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image#javascript-via-node-js
-[macos-javascript]: https://docs.semaphoreci.com/article/120-macos-mojave-image#javascript-via-node-js
+[macos-javascript]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image#javascript-via-node-js
 [docker-env]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker
 [node-docker-image]: https://hub.docker.com/r/semaphoreci/node

--- a/language-python_5bdc36652c7d3a01757aba24.md
+++ b/language-python_5bdc36652c7d3a01757aba24.md
@@ -185,7 +185,7 @@ blocks:
 
 [django-tutorial]: https://docs.semaphoreci.com/article/116-django-continuous-integration
 [ubuntu-python]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image#python
-[macos-python]: https://docs.semaphoreci.com/article/120-macos-mojave-image#python
+[macos-python]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image#python
 [sem-version]: https://docs.semaphoreci.com/article/131-sem-version-managing-language-version-on-linux
 [python-docker-image]: https://hub.docker.com/r/semaphoreci/python
 [docker-env]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker

--- a/language-ruby_5bb9e082042863158cc7236d.md
+++ b/language-ruby_5bb9e082042863158cc7236d.md
@@ -258,6 +258,6 @@ for details on preinstalled browsers and testing tools on Semaphore.
 [rails-database-configuration]: https://guides.rubyonrails.org/configuring.html#configuring-a-database
 [rails-guide]: https://docs.semaphoreci.com/article/99-rails-continuous-integration
 [ubuntu-ruby]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image#ruby
-[macos-ruby]: https://docs.semaphoreci.com/article/120-macos-mojave-image#ruby
+[macos-ruby]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image#ruby
 [ruby-docker-image]: https://hub.docker.com/r/semaphoreci/ruby
 [docker-env]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker

--- a/language-swift_5cd0480e2c7d3a177d6e6388.md
+++ b/language-swift_5cd0480e2c7d3a177d6e6388.md
@@ -1,27 +1,34 @@
-Semaphore supports building, testing and releasing Swift applications in fully
-customizable, autoscaling CI/CD workflows.
+Semaphore allows building, testing and releasing iOS applications with
+customizable CI/CD workflows.
 
 If you’re new to Semaphore, we recommend reading our
-_[Guided tour](https://docs.semaphoreci.com/article/77-getting-started)_ first.
+[guided tour](https://docs.semaphoreci.com/article/77-getting-started) first.
 
-Details on available language and Xcode versions are provided in the [macOS
-image reference][macos-mojave].
+macOS Mojave images running *either* Xcode 10, *or* Xcode 11 are available. Each
+image also has a full complement of useful tools and utilities pre-installed.
+Information on the exact version numbers of macOS, Xcode, fastlane, CocoaPods,
+and all other tools are below:
 
-Minimal Swift project configuration example:
+* [macOS Mojave Xcode 10 Image](macos-xcode-10)
+* [macOS Mojave Xcode 11 Image](macos-xcode-11)
+
+# Configuring Continuous Integration
+
+Below is a minimal `semaphore.yml` which starts an
+[Xcode 11 image](macos-xcode-11) runs `xcodebuild`:
 
 ```yaml
-# .semaphore/semaphore.yml
 version: v1.0
 name: Semaphore iOS Swift example
 agent:
   machine:
     type: a1-standard-4
-    os_image: macos-mojave-xcode10
+    os_image: macos-mojave-xcode11
 blocks:
   - name: Build
     task:
       jobs:
-        - name: checkout code + build the project
+        - name: Checkout and build
           commands:
             - checkout
             - xcodebuild
@@ -29,14 +36,12 @@ blocks:
 
 ## Example project
 
-Semaphore maintains a fully-featured example Swift project demonstrating
-how to set up CI with Fastlane:
+Semaphore maintains an [example project](example-project) built with Swift and
+SwiftUI demonstrating how to set build an app and run tests. A
+[full tutorial showing how to configure an iOS project for CI with Semaphore](example-project)
+is also available.
 
-- [Example project on GitHub][demo-project]
-- [iOS continuous integration with Semaphore tutorial][ios-tutorial] —
-  recommended read if you're setting up an iOS project on Semaphore for the
-  first time.
-
-[macos-mojave]: https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image
-[demo-project]: https://github.com/semaphoreci-demos/semaphore-demo-ios-swift-xcode
+[macos-xcode-10]: https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image
+[macos-xcode-11]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image
+[example-project]: https://github.com/semaphoreci-demos/semaphore-demo-ios-swift-xcode
 [ios-tutorial]: https://docs.semaphoreci.com/article/124-ios-continuous-integration-xcode

--- a/machine-types_5b24032b0428632c466af399.md
+++ b/machine-types_5b24032b0428632c466af399.md
@@ -140,4 +140,4 @@ Apple machine types can be paired with the [MacOS Mojave image][macos-mojave].
 
 [agent]: https://docs.semaphoreci.com/article/50-pipeline-yaml#agent
 [ubuntu1804]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image
-[macos-mojave]: https://docs.semaphoreci.com/article/120-macos-mojave-image
+[macos-mojave]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image

--- a/macos-mojave-xcode-10-image_5d88dd632c7d3a7e9ae17dd1.md
+++ b/macos-mojave-xcode-10-image_5d88dd632c7d3a7e9ae17dd1.md
@@ -9,7 +9,7 @@ named `semaphore`, has full `sudo` access.
 
 [[__TOC__]]
 
-## Using the macos-mojave OS image in your agent configuration
+## Using the macos-mojave-xcode10 OS image in your agent configuration
 
 To use the `macos-mojave-xcode10` OS image, define it as the `os_image` of your agent's
 machine.

--- a/macos-mojave-xcode-11-image_5d88deae04286364bc8f6e8b.md
+++ b/macos-mojave-xcode-11-image_5d88deae04286364bc8f6e8b.md
@@ -9,7 +9,7 @@ named `semaphore`, has full `sudo` access.
 
 [[__TOC__]]
 
-## Using the macos-mojave OS image in your agent configuration
+## Using the macos-mojave-xcode11 OS image in your agent configuration
 
 To use the `macos-mojave-xcode11` OS image, define it as the `os_image` of your agent's
 machine.

--- a/pipeline-yaml_5b5744d40428631d7a8940a9.md
+++ b/pipeline-yaml_5b5744d40428631d7a8940a9.md
@@ -1952,6 +1952,6 @@ YAML parser, which is not a Semaphore 2.0 feature but the way YAML files work.
 
 [ubuntu1804]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image
 [macos-mojave-xcode11]: https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image
-[macos-mojave-xcode10]: https://docs.semaphoreci.com/article/120-macos-mojave-xcode-10-image
+[macos-mojave-xcode10]: https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image
 [conditions-reference]:https://docs.semaphoreci.com/article/142-conditions-reference
 [when-repo-skip-exemples]: https://github.com/renderedtext/when#skip-block-exection

--- a/tour4-build-env_5bb917152c7d3a04dd5b5d66.md
+++ b/tour4-build-env_5bb917152c7d3a04dd5b5d66.md
@@ -35,7 +35,7 @@ Alternatively, if you want to run a MacOS based pipeline, configure it with:
 agent:
   machine:
     type: a1-standard-2    # Apple machine type with 2 vCPUs, 4 GB of RAM
-    os_image: macos-mojave # MacOS Mojave os image
+    os_image: macos-mojave-xcode11 # MacOS Mojave os image
 ```
 
 If you prefer to have a fully custom, containerized environment, define one or
@@ -91,7 +91,7 @@ Cache servers, or other background services like RabbitMQ or Kafka.
 Let's learn how to do that in [the next section][next].
 
 [ubuntu]: https://docs.semaphoreci.com/article/32-ubuntu-1804-image
-[macos]: https://docs.semaphoreci.com/article/120-macos-mojave-image
+[macos]: https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image
 [docker]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker
 [private-images]: https://docs.semaphoreci.com/article/127-custom-ci-cd-environment-with-docker#pulling-private-docker-images-from-dockerhub
 [next]: https://docs.semaphoreci.com/article/129-using-databases-and-services


### PR DESCRIPTION
I'm working on the documentation for the Swift language page, and also the iOS CI tutorial but I found several dead links and broken image names while I was working. This PR fixes all of those that are *not* in the two documents I'm working on, so as to avoid merge conflicts when I submit those as a PR later.

There are still some references to the old image type in the file `macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md` but I'm not sure that's on the docs site anymore. At least I can't find it on the public version of the site. I believe that file has been replaced by the [Xcode 10 image](https://docs.semaphoreci.com/article/161-macos-mojave-xcode-10-image), and the [Xcode 11 image](https://docs.semaphoreci.com/article/162-macos-mojave-xcode-11-image) documents.

Can `macos-mojave_5c6d3bfa2c7d3a66e32eaf2e.md` be deleted? This pull request does *not* include that deletion, but I will update it if it can be removed. 

