### PR TITLE
Fix the example for building a minimal image

### DIFF
--- a/docs/ci-cd-environment/custom-ci-cd-environment-with-docker.md
+++ b/docs/ci-cd-environment/custom-ci-cd-environment-with-docker.md
@@ -138,7 +138,8 @@ with the following Dockerfile:
 ``` Dockerfile
 FROM ubuntu:18.04
 
-RUN apt-get -y update && apt-get install -y git lftp docker openssh-client coreutils
+RUN apt-get -y update && apt-get install -y git lftp openssh-client coreutils
+RUN curl -sSL https://get.docker.com/ | sh
 ```
 
 ### Extending Semaphore's pre-build convenience Docker images


### PR DESCRIPTION
Ref: https://stackoverflow.com/questions/30379381/docker-command-not-found-even-though-installed-with-apt-get