### PR TITLE
Add webhook notification page to references and guided tour

### DIFF
--- a/docs/guided-tour/slack-notifications.md
+++ b/docs/guided-tour/slack-notifications.md
@@ -213,7 +213,7 @@ for further details.
 ## Setting up, editing and deleting Slack notifications through the UI
 
 In the Configuration part of the sidebar, click on **Notifications** -> **Create New
-Notification**. Add the name of the notification and rules and click on the **Save
+Notification**. Add the name of the notification and rules, then click on the **Save
 Changes** button.
 
 If you’d like to edit or delete an existing notification, click on the name of

--- a/docs/guided-tour/webhook-notifications.md
+++ b/docs/guided-tour/webhook-notifications.md
@@ -1,7 +1,7 @@
 # Webhook Notifications
 
 Semaphore has webhook based notifications that are delivered on the success or
-failure of a pipeline. When criteria for notification are met, Semaphore will
+failure of a pipeline. When criteria for notifications are met, Semaphore will
 send a HTTP POST payload to the webhook's configured URL. You can use them,
 for example, to implement alerts through [Hubot](https://github.com/hubotio/hubot),
 or keep track of your projects on a company dashboard.
@@ -30,11 +30,11 @@ $ sem create notification master-pipelines \
 
 ## Setting up webhook notifications for multiple projects
 
-When creating a notification, you can specify multiple projects as source,
+When creating a notification, you can specify multiple projects as a source,
 of your notifications.
 
 For example, if your team manages three projects named `web`, `cli` and `api`
-and you want to get notified for every finished pipeline on the master branch,
+and you want to get notified of every finished pipeline on the master branch,
 use the following command:
 
 ``` bash
@@ -49,7 +49,7 @@ $ sem create notifications teamA-notifications \
 When creating a notification, you can specify a filter for project, branch and
 pipeline names.
 
-For example to send notifications for the `master` and `staging` branches use
+For example, to send notifications for the `master` and `staging` branches, use
 the following:
 
 ``` bash
@@ -68,8 +68,8 @@ $ sem create notifications example \
     --webhook-endpoint [webhook-endpoint] \
 ```
 
-Matching can be specified for project and pipeline names as well. For example,
-if you want to get notified about every notification on a project that matches
+Matching can be specified for project and pipeline files as well. For example,
+if you want to get notified after every pipeline on a project that matches
 `/.*-api$/`, on the master branch, when the `prod.yml` pipeline is executed, use:
 
 ``` bash
@@ -244,8 +244,8 @@ The payload contains all the information related to a pipeline.
 ```
 
 In this example `revision.pull_request` and `revision.tag` are null because
-payload is related to pipeline run started from a push to the branch. Information
-about this is kept in `revision.reference_type`.
+payload is related to the pipeline run started from a push to the branch.
+Information about this is kept in `revision.reference_type`.
 
 Sample `pull_request` object:
 

--- a/docs/reference/slack-notifications.md
+++ b/docs/reference/slack-notifications.md
@@ -137,7 +137,7 @@ spec:
           endpoint: https://hooks.slack.com/services/xxx/yyy/zzz
 ```
 
-Note that you can list more than value under `results`.
+Note that you can list more than one value under `results`.
 
 You can create a notification using the file above with:
 
@@ -212,8 +212,8 @@ for further details.
 
 ## Setting up, editing and deleting Slack notifications through the UI
 
-In the Configuration part of the sidebar, click on **Notifications** -> **Create New 
-Notification**. Add the name of the notification and rules and click on the **Save 
+In the Configuration part of the sidebar, click on **Notifications** -> **Create New
+Notification**. Add the name of the notification and rules and click on the **Save
 Changes** button.
 
 If you’d like to edit or delete an existing notification, click on the name of
@@ -223,3 +223,4 @@ and follow the steps from there.
 ## See also
 
 - [Sem command line tool reference](https://docs.semaphoreci.com/article/53-sem-reference)
+- [Slack Notifications](https://docs.semaphoreci.com/article/91-slack-notifications)

--- a/docs/reference/slack-notifications.md
+++ b/docs/reference/slack-notifications.md
@@ -213,7 +213,7 @@ for further details.
 ## Setting up, editing and deleting Slack notifications through the UI
 
 In the Configuration part of the sidebar, click on **Notifications** -> **Create New
-Notification**. Add the name of the notification and rules and click on the **Save
+Notification**. Add the name of the notification and rules, then click on the **Save
 Changes** button.
 
 If you’d like to edit or delete an existing notification, click on the name of

--- a/docs/reference/webhook-notifications.md
+++ b/docs/reference/webhook-notifications.md
@@ -30,7 +30,7 @@ $ sem create notification master-pipelines \
 
 ## Setting up webhook notifications for multiple projects
 
-When creating a notification, you can specify multiple projects as a source,
+When creating a notification, you can specify multiple projects as a source
 of your notifications.
 
 For example, if your team manages three projects named `web`, `cli` and `api`

--- a/docs/reference/webhook-notifications.md
+++ b/docs/reference/webhook-notifications.md
@@ -1,7 +1,7 @@
 # Webhook Notifications
 
 Semaphore has webhook based notifications that are delivered on the success or
-failure of a pipeline. When criteria for notification are met, Semaphore will
+failure of a pipeline. When criteria for notifications are met, Semaphore will
 send a HTTP POST payload to the webhook's configured URL. You can use them,
 for example, to implement alerts through [Hubot](https://github.com/hubotio/hubot),
 or keep track of your projects on a company dashboard.
@@ -30,11 +30,11 @@ $ sem create notification master-pipelines \
 
 ## Setting up webhook notifications for multiple projects
 
-When creating a notification, you can specify multiple projects as source,
+When creating a notification, you can specify multiple projects as a source,
 of your notifications.
 
 For example, if your team manages three projects named `web`, `cli` and `api`
-and you want to get notified for every finished pipeline on the master branch,
+and you want to get notified of every finished pipeline on the master branch,
 use the following command:
 
 ``` bash
@@ -49,7 +49,7 @@ $ sem create notifications teamA-notifications \
 When creating a notification, you can specify a filter for project, branch and
 pipeline names.
 
-For example to send notifications for the `master` and `staging` branches use
+For example, to send notifications for the `master` and `staging` branches, use
 the following:
 
 ``` bash
@@ -68,8 +68,8 @@ $ sem create notifications example \
     --webhook-endpoint [webhook-endpoint] \
 ```
 
-Matching can be specified for project and pipeline names as well. For example,
-if you want to get notified about every notification on a project that matches
+Matching can be specified for project and pipeline files as well. For example,
+if you want to get notified after every pipeline on a project that matches
 `/.*-api$/`, on the master branch, when the `prod.yml` pipeline is executed, use:
 
 ``` bash
@@ -244,8 +244,8 @@ The payload contains all the information related to a pipeline.
 ```
 
 In this example `revision.pull_request` and `revision.tag` are null because
-payload is related to pipeline run started from a push to the branch. Information
-about this is kept in `revision.reference_type`.
+payload is related to the pipeline run started from a push to the branch.
+Information about this is kept in `revision.reference_type`.
 
 Sample `pull_request` object:
 

--- a/docs/reference/webhook-notifications.md
+++ b/docs/reference/webhook-notifications.md
@@ -1,0 +1,274 @@
+# Webhook Notifications
+
+Semaphore has webhook based notifications that are delivered on the success or
+failure of a pipeline. When criteria for notification are met, Semaphore will
+send a HTTP POST payload to the webhook's configured URL. You can use them,
+for example, to implement alerts through [Hubot](https://github.com/hubotio/hubot),
+or keep track of your projects on a company dashboard.
+
+## Setting up webhook notifications for a project
+
+Use your Endpoint URL to set up a notification on Semaphore,
+with the following command:
+
+``` bash
+$ sem create notification [name] \
+    --projects [project_name] \
+    --webhook-endpoint [webhook-endpoint]
+```
+
+For example, if you have a project called `web` and you want to get a webhook
+notification on every finished pipeline on the `master` branch, use the
+following command:
+
+``` bash
+$ sem create notification master-pipelines \
+    --projects web \
+    --branches master \
+    --webhook-endpoint [webhook-endpoint]
+```
+
+## Setting up webhook notifications for multiple projects
+
+When creating a notification, you can specify multiple projects as source,
+of your notifications.
+
+For example, if your team manages three projects named `web`, `cli` and `api`
+and you want to get notified for every finished pipeline on the master branch,
+use the following command:
+
+``` bash
+$ sem create notifications teamA-notifications \
+    --projects "web,cli,api" \
+    --branches "master" \
+    --webhook-endpoint [webhook-endpoint]
+```
+
+## Filtering by project, branch and pipeline names
+
+When creating a notification, you can specify a filter for project, branch and
+pipeline names.
+
+For example to send notifications for the `master` and `staging` branches use
+the following:
+
+``` bash
+$ sem create notifications example \
+    --branches "master,staging" \
+    --webhook-endpoint [webhook-endpoint] \
+```
+
+A filter can either be a regex match or a direct match. Specifying a filter with
+forward slashes (e.g. `/hotfix-.*/`) defines a regex match, while a filter without
+forward slashes (e.g. `master`) defines a direct match.
+
+``` bash
+$ sem create notifications example \
+    --branches "master,/hotfix\/.*/" \
+    --webhook-endpoint [webhook-endpoint] \
+```
+
+Matching can be specified for project and pipeline names as well. For example,
+if you want to get notified about every notification on a project that matches
+`/.*-api$/`, on the master branch, when the `prod.yml` pipeline is executed, use:
+
+``` bash
+$ sem create notifications example \
+    --projects "/.*api$/" \
+    --branches "master" \
+    --pipelines "prod.yml" \
+    --webhook-endpoint [webhook-endpoint] \
+```
+
+## Advanced notification setup
+
+In the previous examples we looked at simple use cases where we used the CLI
+interface to set up a new notification.
+
+For more complex use cases, defining a notification YAML resource offers full
+control over the rules used for dispatching notifications.
+
+### Filtering by pipeline result
+
+You can specify notifications to be sent only on specific pipeline results.
+
+Available values for the results filter are:
+
+- `passed`
+- `failed`
+- `stopped`
+- `canceled`
+
+Example YAML configuration:
+
+``` yaml
+# notify-on-fail.yml
+
+apiVersion: v1alpha
+kind: Notification
+metadata:
+  name: notify-on-fail
+spec:
+  rules:
+    - name: "Example"
+      filter:
+        projects:
+          - example-project
+        results:
+          - failed
+      notify:
+        webhook:
+          endpoint: https://example.org/postreceiver
+```
+
+Note that you can list more than one value under `results`.
+
+You can create a notification using the file above with:
+
+``` bash
+sem create -f notify-on-fail.yml
+```
+
+## Modifying notification settings
+
+Notification settings can be listed, described, edited and deleted in your
+organization by using the [sem command line tool](https://docs.semaphoreci.com/article/53-sem-reference).
+
+- List notifications with: `sem get notifications`
+- Describe a notification with: `sem get notifications [name]`
+- Edit a notification with: `sem edit notification [name]`
+- Delete a notification with: `sem delete notification [name]`
+
+See the [sem command line tool](https://docs.semaphoreci.com/article/53-sem-reference)
+for further details.
+
+## Setting up, editing and deleting webhook notifications through the UI
+
+In the Configuration part of the sidebar, click on **Notifications** -> **Create New
+Notification**. Add the name of the notification and rules and click on the **Save
+Changes** button.
+
+If you’d like to edit or delete an existing notification, click on the name of
+the notification and at the top right corner, click on **Edit** or **Delete...** button
+and follow the steps from there.
+
+## Notification payload
+
+The payload contains all the information related to a pipeline.
+
+```json
+{
+    "version": "1.0.0",
+    "organization": {
+        "name": "semaphore",
+        "id": "36360e31-fee6-42b2-9f6c-999d4c06ce81"
+    },
+    "project": {
+        "name": "notifications",
+        "id": "91e34570-bebe-42b6-b47a-ca710b2b8927"
+    },
+    "repository": {
+        "url": "https://github.com/renderedtext/notifications",
+        "slug": "renderedtext/notifications"
+    },
+    "revision": {
+        "tag": null,
+        "sender": {
+            "login": "radwo",
+            "email": "184065+radwo@users.noreply.github.com",
+            "avatar_url": "https://avatars2.githubusercontent.com/u/184065?v=4"
+        },
+        "reference_type": "branch",
+        "reference": "refs/heads/rw/webhook_impl",
+        "pull_request": null,
+        "commit_sha": "2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563",
+        "commit_message": "empty",
+        "branch": {
+            "name": "rw/webhook_impl",
+            "commit_range": "36ebdf6e906cf3491391442d2f779b512ca49485...2d9f5fcec1ca7c68fa7bd44dd58ec4ff65814563"
+        }
+    },
+    "workflow": {
+        "initial_pipeline_id": "fa02c7bd-7a8b-42e0-8d6e-aa0d8a194e19",
+        "id": "acabe58e-4bcc-4d39-be06-e98d71917703",
+        "created_at": "2019-12-10T13:09:54Z"
+    },
+    "pipeline": {
+        "yaml_file_name": "semaphore.yml",
+        "working_directory": ".semaphore",
+        "stopping_at": "2019-12-10T13:10:22Z",
+        "state": "done",
+        "running_at": "2019-12-10T13:09:58Z",
+        "result_reason": "user",
+        "result": "stopped",
+        "queuing_at": "2019-12-10T13:09:55Z",
+        "pending_at": "2019-12-10T13:09:55Z",
+        "name": "Notificaitons",
+        "id": "fa02c7bd-7a8b-42e0-8d6e-aa0d8a194e19",
+        "error_description": "",
+        "done_at": "2019-12-10T13:10:28Z",
+        "created_at": "2019-12-10T13:09:54Z"
+    },
+    "blocks": [
+        {
+            "state": "done",
+            "result_reason": "user",
+            "result": "stopped",
+            "name": "List & Test & Build",
+            "jobs": [
+                {
+                    "status": "finished",
+                    "result": "stopped",
+                    "name": "Test",
+                    "index": 1,
+                    "id": "21df03d2-c4e0-4e0a-acd7-5ff60dc0727e"
+                },
+                {
+                    "status": "finished",
+                    "result": "stopped",
+                    "name": "Build",
+                    "index": 2,
+                    "id": "84190263-362c-4051-8260-e43637f148de"
+                },
+                {
+                    "status": "finished",
+                    "result": "passed",
+                    "name": "Lint",
+                    "index": 0,
+                    "id": "d4b93a5b-69a5-43e6-ab24-06b095fc49bf"
+                }
+            ]
+        }
+    ]
+}
+```
+
+In this example `revision.pull_request` and `revision.tag` are null because
+payload is related to pipeline run started from a push to the branch. Information
+about this is kept in `revision.reference_type`.
+
+Sample `pull_request` object:
+
+```json
+"pull_request": {
+  "head_repo_slug": "renderedtext/notifications",
+  "number": 2,
+  "name": "Add docs for webhook notifications",
+  "head_sha": "9872252e00ac5a6b5870cdf94efe0e04770ad104",
+  "branch_name": "webhook_notifications",
+  "commit_range": "9872252e00ac5a6b5870cdf94efe0e04770ad104^..9872252e00ac5a6b5870cdf94efe0e04770ad104"
+}
+```
+
+Sample `tag` object:
+
+```json
+"tag": {
+  "name": "v1.0.1",
+}
+```
+
+## See also
+
+- [Sem command line tool reference](https://docs.semaphoreci.com/article/53-sem-reference)
+- [Webhook Notification](https://docs.semaphoreci.com/article/170-webhook-notifications)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ nav:
     - Deploying with promotions: guided-tour/deploying-with-promotions.md
     - Migration guide for Semaphore Classic users: guided-tour/migration-guide-for-semaphore-classic-users.md
     - Slack notifications: guided-tour/slack-notifications.md
+    - Webhook notifications: guided-tour/webhook-notifications.md
   - Use Cases:
     - Tutorials and example projects: use-cases/tutorials-and-example-projects.md
     - Artifacts: use-cases/artifacts.md
@@ -138,6 +139,7 @@ nav:
     - Jobs YAML reference: reference/jobs-yaml-reference.md
     - Notifications YAML reference: reference/notifications-yaml-reference.md
     - Slack notifications: reference/slack-notifications.md
+    - Webhook notifications: reference/webhook-notifications.md
     - Semaphore Changelog: reference/semaphore-changelog.md
     - Quotas and limits: reference/quotas-and-limits.md
     - Conditions reference: reference/conditions-reference.md


### PR DESCRIPTION
[doc is already on production ](https://docs.semaphoreci.com/guided-tour/webhook-notifications/) in this PR I adding it to `guided-tour` and `reference` sections, just like `slack-notifications` note.