### PR TITLE
Add Ruby 2.7.0 to supported Ruby versions

### DIFF
--- a/docs/ci-cd-environment/ubuntu-18.04-image.md
+++ b/docs/ci-cd-environment/ubuntu-18.04-image.md
@@ -190,6 +190,7 @@ Available versions:
 - 2.4.0 to 2.4.9
 - 2.5.0 to 2.5.7
 - 2.6.0 to 2.6.5
+- 2.7.0
 - jruby-9.1.17.0
 
 ## See Also


### PR DESCRIPTION
I've tested using Ruby 2.7.0 using `sem-version ruby 2.7.0`, and it seemed to work:

```
sem-version ruby 2.7.0
[13:52 14/01/2020]: Changing 'ruby' to version 2.7.0
[13:52 14/01/2020]: Switch successful.
```