### PR TITLE
updating to ssh-add only the created key

### DIFF
--- a/docs/use-cases/using-private-dependencies.md
+++ b/docs/use-cases/using-private-dependencies.md
@@ -62,9 +62,9 @@ blocks:
       prologue:
         commands:
           # Correct premissions since they are too open by default:
-          - chmod 0600 ~/.ssh/*
+          - chmod 0600 ~/.ssh/private-repo
           # Add the key to the ssh agent:
-          - ssh-add ~/.ssh/*
+          - ssh-add ~/.ssh/private-repo
           - checkout
           # Now bundler/yarn/etc are able to pull private dependencies:
           - bundle install


### PR DESCRIPTION
when adding `~/.ssh/*` it adds all sorts of stuff like `authorized_keys`, `config`, `known_hosts` and this causes a failure.