### PR TITLE
include the git sha in the cache key for the build

### DIFF
--- a/docs/examples/continuous-deployment-of-a-static-website.md
+++ b/docs/examples/continuous-deployment-of-a-static-website.md
@@ -67,7 +67,7 @@ blocks:
           - npm run build:all
           # The script puts website files in directory `public`,
           # store it in cache to propagate to deployment:
-          - cache store website-build public
+          - cache store website-build-$SEMAPHORE_GIT_SHA public
 
 promotions:
   - name: Production deploy
@@ -121,7 +121,7 @@ blocks:
         - name: Copy to S3
           commands:
             - checkout
-            - cache restore website-build
+            - cache restore website-build-$SEMAPHORE_GIT_SHA
             - aws s3 sync "public" "s3://bucket-name" --acl "public-read"
 ```
 


### PR DESCRIPTION
When we followed this example, we found that reusing the same cache key on every build typically resulted in build results from a previous run being restored instead of deploying the correct changes. Our solution was to include the gitsha in the cache key.