### PR TITLE
changing ssh-add command to avoid possible failures

### DIFF
--- a/docs/essentials/using-private-dependencies.md
+++ b/docs/essentials/using-private-dependencies.md
@@ -62,9 +62,9 @@ blocks:
       prologue:
         commands:
           # Correct premissions since they are too open by default:
-          - chmod 0600 ~/.ssh/*
+          - chmod 0600 ~/.ssh/id_rsa_semaphoreci
           # Add the key to the ssh agent:
-          - ssh-add ~/.ssh/*
+          - ssh-add ~/.ssh/id_rsa_semaphoreci
           - checkout
           # Now bundler/yarn/etc are able to pull private dependencies:
           - bundle install


### PR DESCRIPTION
Editing this command so it won't attempt to add stuff that is not an SSH key
```bash
ssh-add ~/.ssh/*
Error loading key "/root/.ssh/config": invalid format
Identity added: /root/.ssh/id_rsa (/root/.ssh/id_rsa)
Error loading key "/root/.ssh/known_hosts": invalid format
Identity added: /root/.ssh/semaphore_cache_key (/root/.ssh/semaphore_cache_key)
```