### PR TITLE
[wip] Add CI/CD envs section to front page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,4 +74,17 @@
         </div>
     </div>
 
+    <div class="welcome-blocks-wrapper">
+        <div class="welcome-block">
+            <h2 id="semaphore20cicdenvs">CI/CD Environments</h2>
+            <p class="welcome-block-description">Explore the build environments</p>
+
+            <ul>
+              <li><a href="ci-cd-environment/ubuntu-18.04-image">Build on Linux</a></li>
+              <li><a href="ci-cd-environment/macos-catalina-xcode-11-image">Build on macOS</a></li>
+              <li><a href="ci-cd-environment/custom-ci-cd-environment-with-docker">Build in your own Docker images</a></li>
+            </ul>
+        </div>
+    </div>
+
 </div>


### PR DESCRIPTION
Mentioning Linux, Mac, and Build in Docker is an important part of discovering CI/CD. It needs to be mentioned on the front page.

While writing this, I noticed that we don't have an entry-point page for `Linux` and `Mac`. I feel that we need a couple of high-level pages for this.

Still WIP. @markoa can you advise me on this one? What is your input?