### PR TITLE
Update using-private-dependencies.md

### DIFF
--- a/docs/essentials/using-private-dependencies.md
+++ b/docs/essentials/using-private-dependencies.md
@@ -63,9 +63,9 @@ blocks:
       prologue:
         commands:
           # Correct premissions since they are too open by default:
-          - chmod 0600 ~/.ssh/id_rsa_semaphoreci
+          - chmod 0600 ~/.ssh/private-repo
           # Add the key to the ssh agent:
-          - ssh-add ~/.ssh/id_rsa_semaphoreci
+          - ssh-add ~/.ssh/private-repo
           - checkout
           # Now bundler/yarn/etc are able to pull private dependencies:
           - bundle install


### PR DESCRIPTION
The filename used in the 'secret' and the filename used in the semaphore.yml file need to line up.

I will also note, that I had to put 'checkout' above the ssh-add line. I'm not sure exactly why, but if 'checkout' came after ssh-add, it could not find my main repo at all and I got an error: 

"bash: cd: my_app_name: No such file or directory
Revision: b16ffdfa4945a16dcbbab57d93d59df1e170e2f6 not found .... Exiting"

Finally, I wanted to note here in case it is of help to anyone, if it hangs on 'Username:' (as it did for me at first with bundler/gems) you should make sure your dependency is pointing to git@github.com:my_repo/mydependency to ensure it uses ssh key based auth and not password auth (doh!).