### PR TITLE
Override template to shorten page title for SEO

### DIFF
--- a/template/html-title.html
+++ b/template/html-title.html
@@ -1,0 +1,3 @@
+{%- block htmltitle %}
+    <title>{% if page and page.title and not page.is_homepage %}{{ page.title }} {% else %} {{ config.site_name }} {% endif %}</title>
+{%- endblock %}

--- a/template/main.html
+++ b/template/main.html
@@ -1,3 +1,4 @@
+{% extends "base.html" %}
 {%- block htmltitle %}
     <title>{% if page and page.title and not page.is_homepage %}{{ page.title }} {% else %} {{ config.site_name }} {% endif %}</title>
 {%- endblock %}


### PR DESCRIPTION
Removes site name from page title on all pages except the home page.