### PR TITLE
Removing secret from example

### DIFF
--- a/docs/ci-cd-environment/custom-ci-cd-environment-with-docker.md
+++ b/docs/ci-cd-environment/custom-ci-cd-environment-with-docker.md
@@ -80,8 +80,6 @@ agent:
     - name: cache
       image: 'registry.semaphoreci.com/redis:5.0'
       
-  image_pull_secrets:
-    - name: dockerhub-pull-secrets
     
 blocks:
   - name: "Hello"


### PR DESCRIPTION
We do not need image_pull_secrets if we are using Semaphore Container Registry.