### PR TITLE
Working navigation for latest mkdocs-material

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -61,9 +61,6 @@ header {
         background-color: #c8e6c9 !important;
     }
 
-    .md-sidebar--secondary {
-        margin-left: 64rem !important;
-    }
 }
 
 .md-grid {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,8 +19,10 @@ theme:
   custom_dir: template
   logo: 'images/logo-white.svg'
   favicon: 'images/favicon.ico'
-  feature:
-    tabs: true
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.sections
   palette:
     primary: 'green'
     accent: 'green'


### PR DESCRIPTION
This should enable navigation for the latest mkdocs-material. A css element also needs to be removed for proper layout. 