### PR TITLE
Update copyright year

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,7 +9,7 @@ repo_name: semaphoreci/docs
 repo_url: https://github.com/semaphoreci/docs
 
 # Copyright
-copyright: '&copy; 2009-2020 Rendered Text'
+copyright: '&copy; 2009-2021 Rendered Text'
 
 theme:
   font:


### PR DESCRIPTION
Noticed this in the docs footer

![image](https://user-images.githubusercontent.com/9396752/124611741-05361300-de72-11eb-8e35-959f2613a211.png)