### PR TITLE
New sidebar on essentials page — Preparation to make Tests a key concept on Semaphore 2.0

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -56,6 +56,12 @@ header {
     box-shadow: 0 2px 4px 0 rgba(0,0,0,0.16), 0 0 0 1px rgba(0,0,0,0.08);
 }
 
+.md-nav[data-md-level="2"] {
+    margin-left: 2px;
+    border-left: 2px solid black;
+    margin-bottom: 1.5em;
+}
+
 @media only screen and (min-width: 76.25em) {
     .md-tabs {
         background-color: #c8e6c9 !important;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,31 +49,38 @@ nav:
   - Guided Tour:
     - Getting started: guided-tour/getting-started.md
   - Essentials:
-    - Concepts: essentials/concepts.md
-    - Workflows and Pipelines: essentials/modeling-complex-workflows.md
-    - Workflow triggers: essentials/project-workflow-trigger-options.md
-    - Workflow scheduler/cron: essentials/schedule-a-workflow-run.md
-    - "Fail-fast": essentials/fail-fast-stop-running-tests-on-the-first-failure.md
-    - Deploying with promotions: essentials/deploying-with-promotions.md
-    - Pipeline queues: essentials/pipeline-queues.md
-    - Auto-cancel: essentials/auto-cancel-previous-pipelines-on-a-new-push.md
-    - Skipping commits: essentials/skip-building-some-commits-with-ci-skip.md
-    - Monorepo workflows: essentials/building-monorepo-projects.md
-    - Tag-triggered deployment: essentials/tag-triggered-deployment.md
-    - Job matrix: essentials/build-matrix.md
-    - Prioritizing jobs: essentials/prioritization.md
-    - Debugging with SSH: essentials/debugging-with-ssh-access.md
-    - Caching: essentials/caching-dependencies-and-directories.md
-    - Artifacts: essentials/artifacts.md
-    - Setting environment variables: essentials/environment-variables.md
-    - Secrets: essentials/using-secrets.md
-    - Slack notifications: essentials/slack-notifications.md
-    - Webhook notifications: essentials/webhook-notifications.md
-    - GitHub status checks: essentials/configuring-github-status-checks.md
-    - Status Badges: essentials/status-badges.md
-    - Private dependencies: essentials/using-private-dependencies.md
-    - Deployment dashboards: essentials/deployment-dashboards.md
-    - Test Summary: essentials/test-summary.md
+    - "Key Concepts":
+      - Overview: essentials/concepts.md
+      - Pipelines: essentials/modeling-complex-workflows.md
+      - Triggers: essentials/project-workflow-trigger-options.md
+      - Scheduler/cron: essentials/schedule-a-workflow-run.md
+      - Artifacts: essentials/artifacts.md
+      - Environment variables: essentials/environment-variables.md
+      - Secrets: essentials/using-secrets.md
+      - Tests: essentials/test-summary.md
+      - Debugging: essentials/debugging-with-ssh-access.md
+
+    - Optimizations:
+      - Caching: essentials/caching-dependencies-and-directories.md
+      - "Fail-fast": essentials/fail-fast-stop-running-tests-on-the-first-failure.md
+      - Auto-cancel: essentials/auto-cancel-previous-pipelines-on-a-new-push.md
+      - Skipping commits: essentials/skip-building-some-commits-with-ci-skip.md
+      - Prioritizing jobs: essentials/prioritization.md
+      - Monorepo workflows: essentials/building-monorepo-projects.md
+      - Job matrix: essentials/build-matrix.md
+
+    - Deployment:
+      - Deploying with promotions: essentials/deploying-with-promotions.md
+      - Pipeline queues: essentials/pipeline-queues.md
+      - Tag-triggered deployment: essentials/tag-triggered-deployment.md
+      - Deployment dashboards: essentials/deployment-dashboards.md
+
+    - Notifications:
+      - Slack notifications: essentials/slack-notifications.md
+      - Webhook notifications: essentials/webhook-notifications.md
+      - GitHub status checks: essentials/configuring-github-status-checks.md
+      - Status Badges: essentials/status-badges.md
+
   - Programming Languages:
     - Android: programming-languages/android.md
     - C: programming-languages/c.md
@@ -139,6 +146,8 @@ nav:
       - Clojure Luminus CI/CD: examples/clojure-luminus-ci-cd.md
       - Change-based execution for monorepos: examples/change-based-execution-for-monorepos.md
       - Using Terraform with Google Cloud: examples/using-terraform-with-google-cloud.md
+      - Using private dependencies: essentials/using-private-dependencies.md
+
     - Deployment:
       - Zeit Now continuous deployment: examples/zeit-now-continuous-deployment.md
       - Publishing Docker images on DockerHub: examples/publishing-docker-images-on-dockerhub.md


### PR DESCRIPTION
This is the first step in making "Tests" a key concept in our product/documentation.
In this PR, I'm reorganizing the Essentials page to make a proper place under the sun for tests.

The thought process was the following:

**Step 1) Current State in Production**

The list of essentials is too huge. Definitely longer than the average attention span of a reader. 
Also, the list is not ordered in any meaningful way so it is hard to consume.

<img width="1550" alt="Screenshot 2021-09-27 at 18 23 48" src="https://user-images.githubusercontent.com/1779493/134950623-6f05f3b4-81ed-491f-985a-4a7cafc31bea.png">

**Step 2) Essentials organized by topic**

I re-organized the links and grouped them into related categories. The group names emerged after the organization.
Tests are introduced as a key concept in this step. 

<img width="1550" alt="Screenshot 2021-09-27 at 18 23 55" src="https://user-images.githubusercontent.com/1779493/134950848-dca33950-4218-4f34-832b-35fccb6cd0a8.png">

**Step 3) Optimizing the visual aspect of the essentials sidebar**

Nested elements in the navigation were visually smushed together. A stronger separation was necessary. I've added some custom CSS to make it nicer.
 
<img width="1550" alt="Screenshot 2021-09-27 at 18 27 31" src="https://user-images.githubusercontent.com/1779493/134951293-6e76cff1-3988-49b5-ac40-476b79388567.png">

---

The navigation changes kept the links intact. Every page is still under the same URL.