### PR TITLE
Reference docs for after_pipeline and environment variables that are injected into after pipeline jobs

### DIFF
--- a/docs/ci-cd-environment/environment-variables.md
+++ b/docs/ci-cd-environment/environment-variables.md
@@ -342,6 +342,9 @@ Example values: `Update Readme.md`
 
 ### Environment Variables injected into after_pipeline jobs
 
+The following environment variables are injected only in
+[after pipeline jobs][after-pipeline-ref]{target="_blank"}.
+
 #### SEMAPHORE\_PIPELINE\_RESULT
 
 The value of the `SEMAPHORE_PIPELINE_RESULT` contains the result of the pipeline.
@@ -443,3 +446,4 @@ This feature adds the following environment variables to every job for a given p
 
 [scheduler]: ../essentials/schedule-a-workflow-run.md
 [setting-env-vars]: ../essentials/environment-variables.md
+[after-pipeline-ref]: /reference/pipeline-yaml-reference/#after_pipeline

--- a/docs/ci-cd-environment/environment-variables.md
+++ b/docs/ci-cd-environment/environment-variables.md
@@ -340,6 +340,64 @@ name of the Pull Request.
 
 Example values: `Update Readme.md`
 
+### Environment Variables injected into after_pipeline jobs
+
+#### SEMAPHORE\_PIPELINE\_RESULT
+
+The value of the `SEMAPHORE_PIPELINE_RESULT` contains the result of the pipeline.
+
+Values: `failed`, `passed`, `canceled`, `stopped`.
+
+#### SEMAPHORE\_PIPELINE\_RESULT\_REASON
+
+The value of the `SEMAPHORE_PIPELINE_RESULT_REASON` contains the reason for
+the pipeline result.
+
+Values: `test`, `malformed`, `stuck`, `internal`, `user`, `strategy`, `timeout`.
+
+#### SEMAPHORE\_PIPELINE\_TOTAL\_DURATION
+
+The value of the `SEMAPHORE_PIPELINE_TOTAL_DURATION` contains the duration of
+the pipeline including queuing time.
+
+The value is expressed in seconds.
+
+#### SEMAPHORE\_PIPELINE\_INIT\_DURATION
+
+The value of the `SEMAPHORE_PIPELINE_INIT_DURATION` contains the duration of
+the pipeline initialization.
+
+The value is expressed in seconds.
+
+#### SEMAPHORE\_PIPELINE\_QUEUEING\_DURATION
+
+The value of the `SEMAPHORE_PIPELINE_QUEUEING_DURATION` contains the time
+the pipeline spent in the queue.
+
+The value is expressed in seconds.
+
+#### SEMAPHORE\_PIPELINE\_RUNNING\_DURATION
+
+The value of the `SEMAPHORE_PIPELINE_RUNNING_DURATION` contains the pipeline
+execution time while the jobs were running.
+
+The value is expressed in seconds.
+
+#### SEMAPHORE\_PIPELINE\_CREATED\_AT
+
+The value of the `SEMAPHORE_PIPELINE_CREATED_AT` is the UNIX epoch timestamp when
+the pipeline was created.
+
+#### SEMAPHORE\_PIPELINE\_STARTED\_AT
+
+The value of the `SEMAPHORE_PIPELINE_STARTED_AT` is the UNIX epoch timestamp when
+the pipeline started running jobs.
+
+#### SEMAPHORE\_PIPELINE\_DONE\_AT
+
+The value of the `SEMAPHORE_PIPELINE_DONE_AT` is the UNIX epoch timestamp when
+when the pipeline was finished.
+
 ### Cache related
 
 The following environment variables are related to the `cache` utility. You can

--- a/docs/reference/pipeline-yaml-reference.md
+++ b/docs/reference/pipeline-yaml-reference.md
@@ -133,8 +133,8 @@ agent:
           value: keyboard-cat
 ```
 !!! info "Semaphore convenience images redirection"
-	Due to the introduction of [Docker Hub rate limits](/ci-cd-environment/docker-authentication/), if you are using a [Docker-based CI/CD environment](/ci-cd-environment/custom-ci-cd-environment-with-docker/) in combination with convenience images Semaphore will **automatically redirect** any pulls from the `semaphoreci` Docker Hub repository to the [Semaphore Container Registry](/ci-cd-environment/semaphore-registry-images/).	
-    
+	Due to the introduction of [Docker Hub rate limits](/ci-cd-environment/docker-authentication/), if you are using a [Docker-based CI/CD environment](/ci-cd-environment/custom-ci-cd-environment-with-docker/) in combination with convenience images Semaphore will **automatically redirect** any pulls from the `semaphoreci` Docker Hub repository to the [Semaphore Container Registry](/ci-cd-environment/semaphore-registry-images/).
+
 Each container entry must define the `name` and `image` property. The name of
 the container is used when linking the containers together, and for defining
 hostnames in the first container.
@@ -157,7 +157,7 @@ Other optional parameters of each container definition can be divided into two g
     - `secrets` - Secrets which hold the data the should be injected into the container. They are defined in the same way as in [task definition][secrets-in-task]. *Note*: currently, only environment variables defined in a secret will be injected into container, the files within the secret will be ignored.
 
 !!! warning "Docker Hub rate limits"
-    Please note that due to the introduction of the [rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) on Docker Hub, all pulls have to be authenticated. 
+    Please note that due to the introduction of the [rate limits](https://docs.docker.com/docker-hub/download-rate-limit/) on Docker Hub, all pulls have to be authenticated.
     If you are pulling any images from Docker Hub public repository please make sure you are logged in to avoid any failiures. You can find more information on how to authenticate in our [Docker authentication](https://docs.semaphoreci.com/ci-cd-environment/docker-authentication/) guide.
 
 ### A Preface example
@@ -188,8 +188,8 @@ The `execution_time_limit` property can be used at the `pipeline`, `block`
 or `job` scope. In the latter two cases you can use the propery for multiple
 blocks or jobs.
 
-*Note*: In the `pipeline` and `block` scopes `execution_time_limit`  will 
-sum the  runtime of all underlying elements, this also includes the time 
+*Note*: In the `pipeline` and `block` scopes `execution_time_limit`  will
+sum the  runtime of all underlying elements, this also includes the time
 jobs are waiting for quota. Please keep this in mind when using the property.
 
 The `execution_time_limit` property can hold two other properties, which are
@@ -1548,6 +1548,49 @@ blocks:
 In this case the name of the file that was saved in a `secret` is `file.txt`
 and is located at the home directory of the VM.
 
+## after_pipeline
+
+The `after_pipeline` property is used for defining a set of jobs that will
+execute when the pipeline is finished. The `after_pipeline` property is most
+commonly used for sending notifications, collecting test results, and submitting
+metrics.
+
+For example, to submit pipeline duration metrics and publish test results, you
+would define the after pipeline with the following YAML snippet:
+
+``` yaml
+after_pipeline:
+  task:
+    jobs:
+      - name: Submit Metrics
+        commands:
+          - echo "ci.duration:$SEMAPHORE_PIPELINE_TOTAL_DURATION|ms" | nc -w 3 -u statsd.example.com
+
+      - name: Publish Tests
+        commands:
+          - test-results gen-pipeline-report
+```
+
+Jobs in the after_pipeline task are always executed regardless of the result
+of the pipeline. This includes passed, failed, stopped and canceled results.
+
+### Environment variables available in the after_pipeline jobs
+
+All `SEMAPHORE_*` environment variables that are injected into regular pipeline
+jobs, are also injected into after pipelines jobs.
+
+Additionally, in the after pipeline jobs, Semaphore injects environment
+variables that are describing the state, result and duration of the executed
+pipeline.
+
+See [which environment variables][after-pipeline-env-vars] are injected into after pipeline jobs.
+
+### Global jobs config is not applied to after_pipeline jobs
+
+Global job config is not applied to after pipeline tasks. This includes secrets,
+prologue and epilogue commands that are defined in the global job configuration
+stanza.
+
 ## promotions
 
 The `promotions` property is used for *promoting* (manually or automatically
@@ -1770,7 +1813,7 @@ syntax, which is, in this case, any string that starts with `v1.`.
 
 As for the `Documentation` promotion, it will be auto-promoted when initiated from
 the `master` branch and there is at least one changed file in the `docs` folder
-(relative to the root of the repository). Check the 
+(relative to the root of the repository). Check the
 [change_in reference][change-in-ref] for additional usage details.
 
 The content of `p1.yml` is as follows:
@@ -2167,3 +2210,4 @@ YAML parser, which is not a Semaphore 2.0 feature but the way YAML files work.
 [default-queue-config]: https://docs.semaphoreci.com/essentials/pipeline-queues#default-behaviour
 [monorepo-workflows]: https://docs.semaphoreci.com/essentials/building-monorepo-projects/
 [change-in-ref]: https://docs.semaphoreci.com/reference/conditions-reference/#change_in
+[after-pipeline-env-vars]: /ci-cd-environment/environment-variables/#environment-variables-injected-into-after_pipeline-jobs

--- a/docs/reference/pipeline-yaml-reference.md
+++ b/docs/reference/pipeline-yaml-reference.md
@@ -1555,7 +1555,7 @@ execute when the pipeline is finished. The `after_pipeline` property is most
 commonly used for sending notifications, collecting test results, and submitting
 metrics.
 
-For example, to submit pipeline duration metrics and publish test results, you
+For example, to submit pipeline duration metrics and to publish test results, you
 would define the after pipeline with the following YAML snippet:
 
 ``` yaml
@@ -1572,7 +1572,8 @@ after_pipeline:
 ```
 
 Jobs in the after_pipeline task are always executed regardless of the result
-of the pipeline. This includes passed, failed, stopped and canceled results.
+of the pipeline. Meaning that the after pipeline jobs are executed on passed,
+failed, stopped, and canceled pipeline.
 
 ### Environment variables available in the after_pipeline jobs
 


### PR DESCRIPTION
Grammar is checked with Grammarly.

It reports the overuse of passive voice. I'm keeping it as it is because the rest of the reference is also heavily using passive voice.