### PR TITLE
Fix links using the hhttps protocol

### DIFF
--- a/docs/ci-cd-environment/ubuntu-18.04-image.md
+++ b/docs/ci-cd-environment/ubuntu-18.04-image.md
@@ -236,5 +236,5 @@ sudo apt-get install -y [your-dependency]
 
 [machine-types]: https://docs.semaphoreci.com/ci-cd-environment/machine-types/
 [agent]: https://docs.semaphoreci.com/reference/pipeline-yaml-reference/#agent
-[sem-version]: hhttps://docs.semaphoreci.com/ci-cd-environment/sem-version-managing-language-versions-on-linux/
+[sem-version]: https://docs.semaphoreci.com/ci-cd-environment/sem-version-managing-language-versions-on-linux/
 [sem-service]: https://docs.semaphoreci.com/ci-cd-environment/sem-service-managing-databases-and-services-on-linux/

--- a/docs/ci-cd-environment/ubuntu-20.04-image.md
+++ b/docs/ci-cd-environment/ubuntu-20.04-image.md
@@ -215,5 +215,5 @@ sudo apt-get install -y [your-dependency]
 
 [machine-types]: https://docs.semaphoreci.com/ci-cd-environment/machine-types/
 [agent]: https://docs.semaphoreci.com/reference/pipeline-yaml-reference/#agent
-[sem-version]: hhttps://docs.semaphoreci.com/ci-cd-environment/sem-version-managing-language-versions-on-linux/
+[sem-version]: https://docs.semaphoreci.com/ci-cd-environment/sem-version-managing-language-versions-on-linux/
 [sem-service]: https://docs.semaphoreci.com/ci-cd-environment/sem-service-managing-databases-and-services-on-linux/

--- a/docs/reference/semaphore-changelog.md
+++ b/docs/reference/semaphore-changelog.md
@@ -1657,7 +1657,7 @@ A detailed list can be found in [Docker images changelog](https://github.com/sem
 
 - New feature: Artifacts. Persistent storage of final CI/CD deliverables,
   intermediary assets and files for debugging. Now in public beta.
-    - [Learn more about use cases](hhttps://docs.semaphoreci.com/essentials/artifacts/) and
+    - [Learn more about use cases](https://docs.semaphoreci.com/essentials/artifacts/) and
   [how to use the artifacts CLI](https://docs.semaphoreci.com/reference/artifact-cli-reference/).
 
 ### Week of September 9, 2019


### PR DESCRIPTION
I clicked a link and nothing opened. When I opened it in a new tab
Firefox said "The address wasn’t understood".

Looks like the `https` protocol was mistyped. I fixed all occurrences a
quick find all returned.