### PR TITLE
How to automate semantic releases on Semaphore

### DIFF
--- a/docs/essentials/releasing-semantic-versions.md
+++ b/docs/essentials/releasing-semantic-versions.md
@@ -1,4 +1,4 @@
-# Releasing Semantic Versions
+# Releasing semantic versions
 
 [Semantic versioning](https://semver.org/) is a formal convention for determining the version number of 
 new software releases. The standard helps software users to understand the severity of changes in each 

--- a/docs/essentials/semantic-releases.md
+++ b/docs/essentials/semantic-releases.md
@@ -1,0 +1,166 @@
+# Releasing Semantic Versions
+
+[Semantic versioning](https://semver.org/) is a formal convention for determining the version number of 
+new software releases. The standard helps software users to understand the severity of changes in each 
+new distribution. A project that uses semantic versioning will advertise a Major, Minor and Patch number
+for each release.
+
+Semaphore integrates with a widely used semantic versioning tool [semantic-release](https://github.com/semantic-release/semantic-release) 
+that automatizes the process and reduces the possibility of human errors. The [sem-semantic-release][sem-semantic-release]
+is a thin wrapper around the CLI that executes the release and exports release information making it
+readily available for the rest of the delivery process.
+
+## Setting up an automatic semantic release deployment process
+
+To set up an automated semantic release process, you will need:
+
+- A secret that grants access permissions to the Git repository where you want to push the release
+- A release pipeline
+- (optional) Configuration parameters for customizing the release process
+
+### Step 1: Create a secret with the Git
+
+Create a new secret in your organization that contains the access credentials.
+Go to Organizations Setting > New Secret:
+
+1. Set the name to semantic-release-credentials
+2. Add an environment variable (TODO)
+3. Save the new secret
+
+The release pipeline will use this secret to connect to your Git repository and 
+generate the new release.
+
+### Step 2: Create a release pipeline
+
+In the main Semaphore pipeline `.semaphore/semaphore.yml` define a promotion that
+will trigger the automated release process:
+
+``` yaml
+name: BUild & Test
+
+blocks:
+  - name: Test
+    jobs:
+      - name: Tests
+        commands:
+          - make test
+
+promotions:
+  - name: Automatic SemVer Release
+    pipeline: release.yaml
+    auto_promote:
+      when: "branch = 'master' or branch =~ 'release/.*'"
+```
+
+Define the release pipeline in your Git repository `.semaphore/release.yml` with the
+following content:
+
+``` yaml
+name: Release
+
+blocks:
+  - name: Release
+    secrets:
+      - name: semantic-release-credentials
+    jobs:
+      - name: Release
+        commands:
+          - sem-semantic-release
+```
+
+### Step 3: Configure the release process (optional)
+
+Create a configuration file in the root of your repository `.releaserc` to
+customize the relase process. The configuration options are described in
+[the documentation of the semantic release CLI](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#options).
+
+### Step 4: Create a release
+
+Switch to the main branch in your repository, and push a new fix:
+
+``` bash
+git switch main
+git commit -m "fix(pencil): stop graphite breaking when too much pressure applied"
+git push
+```
+
+The above command will trigger a new pipeline on Semaphore and generate a new
+Patch release.
+
+## Using the release information in the continuation of your delivery process
+
+The `sem-semantic-release` wraps the semantic release CLI and exports the release
+information to the rest of your delivery process.
+
+The release information is handy when you want continue the delivery process
+after the new release has been created. A common example would be to build
+a Docker image tagged with the release version, or adding an annotation to the
+Kubernetes deployment manifest.
+
+### Exported release infromation
+
+ReleasePublished 	  | Whether a new release was published. The return value is in the form of a string. ("true" or "false")
+ReleaseVersion        | Version of the new release. (e.g. "1.3.0")
+ReleaseMajorVersion   | Major version of the new release. (e.g. "1")
+ReleaseMinorVersion   | Minor version of the new release. (e.g. "3")
+ReleasePatchVersion   | Patch version of the new release. (e.g. "0")
+ReleaseChannel 	      | The distribution channel on which the last release was initially made available.
+ReleaseNotes 	      | The release notes for the new release.
+PeviousReleaseVersion | The previous released version.
+
+### Example 1: Tagging a Docker image with the ReleaseVersion
+
+``` yaml
+name: Release
+
+blocks:
+  - name: Make New Release
+    secrets:
+      - name: semantic-release-credentials
+    jobs:
+      - name: Release
+        commands:
+          - sem-semantic-release
+
+  - name: Release Docker Image
+    secrets:
+      - name: gcr-credentials
+    jobs:
+      - name: Build & push docker image
+        commands:
+          - docker build . -t my-app:$(sem-get ReleaseVersion)
+          - docker push
+```
+
+### Example 2: Tagging a Docker image and releasing a new Kubernetes version
+
+``` yaml
+name: Release
+
+blocks:
+  - name: Make New Release
+    secrets:
+      - name: semantic-release-credentials
+    jobs:
+      - name: Release
+        commands:
+          - sem-semantic-release
+
+  - name: Release Docker Image
+    secrets:
+      - name: gcr-credentials
+    jobs:
+      - name: Build & push docker image
+        commands:
+          - docker build . -t my-app:$(sem-get ReleaseVersion)
+          - docker push
+
+  - name: Update Kubernetes deployment
+    secrets:
+      - name: gke-credentials
+    jobs:
+      - name: kube apply
+        commands:
+          - sed -i "s/IMAGE/$(sem-get ReleaseVersion)" deployment.yml
+          - kubectl apply -f deployment.yml
+```

--- a/docs/essentials/semantic-releases.md
+++ b/docs/essentials/semantic-releases.md
@@ -18,7 +18,7 @@ To set up an automated semantic release process, you will need:
 - A release pipeline
 - (optional) Configuration parameters for customizing the release process
 
-### Step 1: Create a secret with the Git
+### Step 1: Create a secret with the Git credentials
 
 Create a new secret in your organization that contains the access credentials.
 Go to Organizations Setting > New Secret:

--- a/docs/essentials/semantic-releases.md
+++ b/docs/essentials/semantic-releases.md
@@ -2,33 +2,36 @@
 
 [Semantic versioning](https://semver.org/) is a formal convention for determining the version number of 
 new software releases. The standard helps software users to understand the severity of changes in each 
-new distribution. A project that uses semantic versioning will advertise a Major, Minor and Patch number
+new distribution. A project that uses semantic versioning will advertise a Major, Minor, and Patch number
 for each release.
 
-Semaphore integrates with a widely used semantic versioning tool [semantic-release](https://github.com/semantic-release/semantic-release) 
-that automatizes the process and reduces the possibility of human errors. The [sem-semantic-release][sem-semantic-release]
-is a thin wrapper around the CLI that executes the release and exports release information making it
-readily available for the rest of the delivery process.
+Semaphore integrates with a widely used semantic versioning tool: [semantic-release](https://github.com/semantic-release/semantic-release). 
+It automates the process and reduces the possibility of human errors. `sem-semantic-release` is a thin 
+wrapper around semantic-release CLI that executes the release and exports release information. It makes 
+a version number available for the rest of the delivery process.
 
-## Setting up an automatic semantic release deployment process
+## Setting up an automatic semantic release process
 
 To set up an automated semantic release process, you will need:
 
-- A secret that grants access permissions to the Git repository where you want to push the release
-- A release pipeline
+- a configured release pipeline
+- a secret with necessary credentials (e.g. GitHub personal access token)
+- the latest version of Node.js (it is already installed on hosted machines)
 - (optional) Configuration parameters for customizing the release process
 
 ### Step 1: Create a secret with the Git credentials
 
-Create a new secret in your organization that contains the access credentials.
-Go to Organizations Setting > New Secret:
+The secret will contain access credentials to your repository. Go to Organizations Setting > New Secret:
 
-1. Set the name to semantic-release-credentials
-2. Add an environment variable (TODO)
-3. Save the new secret
+1. Set the name to `semantic-release-credentials`.
+2. Add an environment variable according to the [documentation here](https://semantic-release.gitbook.io/semantic-release/usage/ci-configuration#push-access-to-the-remote-repository). As an example, for GitHub set the following:
 
-The release pipeline will use this secret to connect to your Git repository and 
-generate the new release.
+    - name: `GITHUB_TOKEN` or `GH_TOKEN`,
+    - value: [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with repository (`repo`) permissions.
+
+3. Save the new secret.
+
+The release pipeline will use this secret to connect to GitHub and generate the new release.
 
 ### Step 2: Create a release pipeline
 
@@ -36,13 +39,14 @@ In the main Semaphore pipeline `.semaphore/semaphore.yml` define a promotion tha
 will trigger the automated release process:
 
 ``` yaml
-name: BUild & Test
+name: Build & Test
 
 blocks:
   - name: Test
     jobs:
       - name: Tests
         commands:
+          - checkout
           - make test
 
 promotions:
@@ -65,48 +69,48 @@ blocks:
     jobs:
       - name: Release
         commands:
+          - checkout
           - sem-semantic-release
 ```
 
 ### Step 3: Configure the release process (optional)
 
-Create a configuration file in the root of your repository `.releaserc` to
-customize the relase process. The configuration options are described in
-[the documentation of the semantic release CLI](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#options).
+Create a configuration file in the root of your repository `.releaserc` to customize the release process.
+The configuration options and their default values are described in 
+[the documentation of the semantic release CLI](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#options). `sem-semantic-release` uses the latest version of `semantic-release` with pre-installed plugins
+[available in npm](https://www.npmjs.com/package/semantic-release) and its default values.
 
 ### Step 4: Create a release
 
-Switch to the main branch in your repository, and push a new fix:
+Switch to the default branch in your repository, and push a new fix:
 
 ``` bash
 git switch main
+# ... make some changes to your code
 git commit -m "fix(pencil): stop graphite breaking when too much pressure applied"
 git push
 ```
 
-The above command will trigger a new pipeline on Semaphore and generate a new
-Patch release.
+The above command will trigger a new pipeline on Semaphore and generate a new patch release.
 
 ## Using the release information in the continuation of your delivery process
 
-The `sem-semantic-release` wraps the semantic release CLI and exports the release
-information to the rest of your delivery process.
+`sem-semantic-release` wraps the semantic release CLI and exports the release information to the rest 
+of your delivery process. It is handy when you want to continue the delivery process once the release 
+has been created. A common example would be to build a Docker image tagged with the release version, 
+or add an annotation to a Kubernetes deployment manifest.
 
-The release information is handy when you want continue the delivery process
-after the new release has been created. A common example would be to build
-a Docker image tagged with the release version, or adding an annotation to the
-Kubernetes deployment manifest.
+All information is provided as string values.
 
-### Exported release infromation
+### Exported release information
 
-ReleasePublished 	  | Whether a new release was published. The return value is in the form of a string. ("true" or "false")
-ReleaseVersion        | Version of the new release. (e.g. "1.3.0")
-ReleaseMajorVersion   | Major version of the new release. (e.g. "1")
-ReleaseMinorVersion   | Minor version of the new release. (e.g. "3")
-ReleasePatchVersion   | Patch version of the new release. (e.g. "0")
-ReleaseChannel 	      | The distribution channel on which the last release was initially made available.
-ReleaseNotes 	      | The release notes for the new release.
-PeviousReleaseVersion | The previous released version.
+| **Key**                 | **Description**                                             |
+| :---                    | :---                                                        |
+| `ReleasePublished` 	    | Whether a new release was published (`"true"` or `"false"`) |
+| `ReleaseVersion`        | Version of the new release. (e.g. `"1.3.0"`)                |
+| `ReleaseMajorVersion`   | Major version of the new release. (e.g. `"1"`)              |
+| `ReleaseMinorVersion`   | Minor version of the new release. (e.g. `"3"`)              |
+| `ReleasePatchVersion`   | Patch version of the new release. (e.g. `"0"`)              |
 
 ### Example 1: Tagging a Docker image with the ReleaseVersion
 
@@ -125,10 +129,12 @@ blocks:
   - name: Release Docker Image
     secrets:
       - name: gcr-credentials
+    dependencies:
+      - Make New Release
     jobs:
       - name: Build & push docker image
         commands:
-          - docker build . -t my-app:$(sem-get ReleaseVersion)
+          - docker build . -t my-app:$(sem-context get ReleaseVersion)
           - docker push
 ```
 
@@ -149,18 +155,22 @@ blocks:
   - name: Release Docker Image
     secrets:
       - name: gcr-credentials
+    dependencies:
+      - Make New Release
     jobs:
       - name: Build & push docker image
         commands:
-          - docker build . -t my-app:$(sem-get ReleaseVersion)
+          - docker build . -t my-app:$(sem-context get ReleaseVersion)
           - docker push
 
   - name: Update Kubernetes deployment
     secrets:
       - name: gke-credentials
+    dependencies:
+      - Release Docker Image
     jobs:
       - name: kube apply
         commands:
-          - sed -i "s/IMAGE/$(sem-get ReleaseVersion)" deployment.yml
+          - sed -i "s/IMAGE/$(sem-context get ReleaseVersion)" deployment.yml
           - kubectl apply -f deployment.yml
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -153,6 +153,7 @@ nav:
       - Change-based execution for monorepos: examples/change-based-execution-for-monorepos.md
       - Using Terraform with Google Cloud: examples/using-terraform-with-google-cloud.md
       - Using private dependencies: essentials/using-private-dependencies.md
+      - Releasing semantic versions: essentials/releasing-semantic-versions.md
 
     - Deployment:
       - Zeit Now continuous deployment: examples/zeit-now-continuous-deployment.md


### PR DESCRIPTION
This PR introduces a new page on the essentials page, under the deployment category, called Releasing Semantic Versions.

The proposal has three assumptions:
1. We will introduce a new toolbox command called `sem-export [KEY] [VALUE]` that allows exporting information for the whole workflow. Example: `sem-export VERSION 1.2.3`.
2. We will introduce a new toolbox command called `sem-get [KEY]` which fetches a key anywhere else in the workflow. Example: `sem-get VERSION`.
3. Finally, the `sem-semantic-release` will be a thin wrapper around the semantic release CLI that executes the release generation and exports the information to the pipeline.

Pseudocode of the `sem-semantic-release` toolbox command:

```
npm install semantic-relase
npx semantic-release > release.json

FullVersion=$(jq release.yml latest_version)

MajorVersion=$(echo $FullVersion | awk -F '.' { print $1 })
MinorVersion=$(echo $FullVersion | awk -F '.' { print $2 })
PatchVersion=$(echo $FullVersion | awk -F '.' { print $3 })

sem-export ReleaseVersion $FullVersion
sem-export MajorVersion $MajorVersion
sem-export MinorVersion $MinorVersion
sem-export PatchVersion $PatchVersion
```  