### PR TITLE
Note added to Self-hosted pages - available only to enterprise plan

### DIFF
--- a/docs/ci-cd-environment/install-self-hosted-agent.md
+++ b/docs/ci-cd-environment/install-self-hosted-agent.md
@@ -3,6 +3,7 @@ Description: This guide describes how to install a self-hosted agent on various 
 ---
 
 # Installing a self-hosted agent
+
 The Semaphore agent is open source and can be found [here][agent repo]. Before installing it on your machine, you need to make sure the following requirements are also available:
 
 - git
@@ -11,6 +12,9 @@ The Semaphore agent is open source and can be found [here][agent repo]. Before i
 - docker-compose (Linux/MacOS)
 
 Please, follow the installation instructions for your operating system of choice below.
+
+**Note:** Self-hosted agents are only available on our [enterprise plan](https://semaphoreci.com/pricing).
+
 
 ## Installing the agent on Ubuntu/Debian
 

--- a/docs/ci-cd-environment/self-hosted-agent-types.md
+++ b/docs/ci-cd-environment/self-hosted-agent-types.md
@@ -5,6 +5,8 @@ Description: This guide describes how to create and use a self-hosted agent type
 # Using self-hosted agent types
 Before running and using self-hosted agents in your pipelines, you need to register a new agent type in your organization.
 
+**Note:** Self-hosted agents are only available on our [enterprise plan](https://semaphoreci.com/pricing).
+
 ## Creating a self-hosted agent type
 
 1. Go to `<your-organization-name>.semaphoreci.com/self_hosted_agents`

--- a/docs/ci-cd-environment/self-hosted-agents-overview.md
+++ b/docs/ci-cd-environment/self-hosted-agents-overview.md
@@ -5,6 +5,8 @@ Description: This guide gives a brief overview of self-hosted agents and how the
 # Self-hosted agents overview
 Semaphore allows you to run your jobs in an environment which is controlled by your team. This is achieved through the use of self-hosted agents. Additionally, compared to a hosted platform, self-hosted agents offer more control over hardware, operating system versions, and the available software. This is because as you can run the agents anywhere you want: physical or virtual machines, containers, or in the cloud.
 
+**Note:** Self-hosted agents are only available on our [enterprise plan](https://semaphoreci.com/pricing).
+
 ## Agent communication with Semaphore
 
 All communication between the agent and Semaphore is one-way -- from the agent to Semaphore -- and is secured via HTTPS TLS 1.3.


### PR DESCRIPTION
from a customer:
>It should be clearly documented that self-hosted agents is an Enterprise On-Premise only feature. As a current user I should not have to visit marketing pages to verify a feature in the documentation is available to me.

I agree with him :)