### PR TITLE
Suggestion for semantic release docs

### DIFF
--- a/docs/essentials/releasing-semantic-versions.md
+++ b/docs/essentials/releasing-semantic-versions.md
@@ -96,7 +96,9 @@ The above command will trigger a new pipeline on Semaphore and generate a new pa
 ## Using the release information in the continuation of your delivery process
 
 `sem-semantic-release` wraps the semantic release CLI and exports the release information to the rest 
-of your delivery process. It is handy when you want to continue the delivery process once the release 
+of your delivery process using [sem-context put](https://docs.semaphoreci.com/reference/sem-context-reference/#put).
+This information can later be retrieved with [sem-context get](https://docs.semaphoreci.com/reference/sem-context-reference/#get).
+It is handy when you want to continue the delivery process once the release 
 has been created. A common example would be to build a Docker image tagged with the release version, 
 or add an annotation to a Kubernetes deployment manifest.
 


### PR DESCRIPTION
The documentation states that information about the semantic release is exported to the rest of the CICD process. I added a line stating how it is done (via sem-context put), so that maybe someone reading this can familiarise themselves with the sem-context tool, and that the $(sem-context get) line in the .yaml file has more context to it.