### PR TITLE
Clarify that epulogue commands wont run on timed out jobs

### DIFF
--- a/docs/reference/pipeline-yaml-reference.md
+++ b/docs/reference/pipeline-yaml-reference.md
@@ -1371,8 +1371,8 @@ An `epilogue` block should be used when you want to execute commands after
 a job has finished, either successfully or unsuccessfully.
 
 Please notice that a pipeline *will not fail* if one or more commands in the
-`epilogue` fail to execute for some reason. Also, the epilogue doesn't work
-in stopped or canceled jobs.
+`epilogue` fail to execute for some reason. Also, epilogue commands will not run
+if the job was stopped, canceled or timed-out.
 
 There are three types of epilogue commands:
 


### PR DESCRIPTION
Just a quick change that clarifies epilogue commands wont run when the job times out