### PR TITLE
Update skip-building-some-commits-with-ci-skip.md

### DIFF
--- a/docs/essentials/skip-building-some-commits-with-ci-skip.md
+++ b/docs/essentials/skip-building-some-commits-with-ci-skip.md
@@ -12,4 +12,4 @@ commit's message.
 	When squashing commits before merging in another branch, all commit messages will be merged as well. If a previous commit in the current branch contains `[ci skip]` or `[skip ci]`, it will be propagated and the merged commit will not build.
 
 !!! info "Usage with Tag builds"
-	The `[skip ci]` keyword in commit messages is not consistently respected during tag builds. This means that even when `[skip ci]` is included in the commit message, CI/CD builds are still triggered for tag builds.
+	The `[skip ci]` or `[ci skip]` keywords in commit messages are not consistently respected during tag builds. This means that even when `[skip ci]` or `[ci skip]` is included in the commit message, CI/CD builds are still triggered for tag builds.

--- a/docs/essentials/skip-building-some-commits-with-ci-skip.md
+++ b/docs/essentials/skip-building-some-commits-with-ci-skip.md
@@ -10,3 +10,6 @@ commit's message.
 
 !!! info "Usage with squashed commits"
 	When squashing commits before merging in another branch, all commit messages will be merged as well. If a previous commit in the current branch contains `[ci skip]` or `[skip ci]`, it will be propagated and the merged commit will not build.
+
+!!! info "Usage with Tag builds"
+	The `[skip ci]` keyword in commit messages is not consistently respected during tag builds. This means that even when `[skip ci]` is included in the commit message, CI/CD builds are still triggered for tag builds.


### PR DESCRIPTION
Updated the skip-building-some-commits-with-ci-skip.md to include that [ci skip]/[skip ci] is not respected during Tag builds.