### PR TITLE
Remove tech preview warning

### DIFF
--- a/docs/ci-cd-environment/ubuntu-22.04-image.md
+++ b/docs/ci-cd-environment/ubuntu-22.04-image.md
@@ -6,8 +6,6 @@ Description: The ubuntu2204 image is a customized image based on Ubuntu 22.04 LT
 
 !!! plans "Available on: <span class="plans-box">Startup</span> <span class="plans-box">Scaleup</span>"
 
-!!! warning "The `ubuntu2204` image is in the Technical Preview stage. Documentation and the image itself are subject to change."
-
 The `ubuntu2204` image is a customized image based on [Ubuntu 22.04 LTS](https://wiki.ubuntu.com/JammyJellyfish/ReleaseNotes), which has been
 optimized for CI/CD. It comes with a set of preinstalled languages, databases,
 and utility tools commonly used for CI/CD workflows.


### PR DESCRIPTION
The goal of this PR is to remove the Tech Preview warning from Ubuntu 22.04 image description since it is generally available for 10 months, we are updating it regularly, no major issues were found.