### PR TITLE
Github admin is assigned Semaphore Contributor role

### DIFF
--- a/docs/security/repository-to-role-mappings.md
+++ b/docs/security/repository-to-role-mappings.md
@@ -29,7 +29,7 @@ is assigned to them on the Semaphore project.
     Admin
   </td>
   <td>
-    Admin
+    Contributor
   </td>
 </tr>
 <tr>
@@ -66,7 +66,7 @@ is assigned to them on the Semaphore project.
     Admin
   </td>
   <td>
-    Admin
+    Contributor
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
There was an error in docs, stating that if the user has admin access to the GitHub repo, they will have Admin access within the Semaphore project. That is not the case, they will have a "Contributor" role assigned within the project. Admin role on semaphore has to be assigned manually.