### PR TITLE
add RHEL FIPS enabled host instructions

### DIFF
--- a/docs/ci-cd-environment/aws-support.md
+++ b/docs/ci-cd-environment/aws-support.md
@@ -21,7 +21,7 @@ If you intend to run your agents on AWS, the [agent-aws-stack][agent-aws-stack] 
 
 The [agent-aws-stack][agent-aws-stack] is an [AWS CDK][aws cdk] application written in JavaScript, which depends on a few things to work:
 
-- Node v16+ and NPM, for building and deploying the CDK application and managing its dependencies
+- Node v18+ and NPM, for building and deploying the CDK application and managing its dependencies
 - Make, Python 3.9+, and Packer for AMI creation and provisioning
 - Properly-configured [AWS credentials][aws credentials]
 
@@ -32,9 +32,9 @@ In order to follow the steps below, please make sure that your AWS user has the 
 ### 1. Download the CDK application and installing dependencies
 
 ```
-curl -sL https://github.com/renderedtext/agent-aws-stack/archive/refs/tags/v0.3.2.tar.gz -o agent-aws-stack.tar.gz
+curl -sL https://github.com/renderedtext/agent-aws-stack/archive/refs/tags/v0.3.4.tar.gz -o agent-aws-stack.tar.gz
 tar -xf agent-aws-stack.tar.gz
-cd agent-aws-stack-0.3.2
+cd agent-aws-stack-0.3.4
 npm i
 ```
 
@@ -170,6 +170,7 @@ Create a `config.json` file with the following:
   "SEMAPHORE_AGENT_OS": "macos",
   "SEMAPHORE_AGENT_DISCONNECT_AFTER_IDLE_TIMEOUT": "86400",
   "SEMAPHORE_AGENT_MAC_FAMILY": "mac1",
+  "SEMAPHORE_AGENT_INSTANCE_TYPE": "mac1.metal",
   "SEMAPHORE_AGENT_AZS": "us-east-1a,us-east-1b,us-east-1d",
   "SEMAPHORE_AGENT_LICENSE_CONFIGURATION_ARN": "arn:aws:license-manager:<region>:<accountId>:license-configuration:<your-license-configuration>"
 }

--- a/docs/ci-cd-environment/install-self-hosted-agent.md
+++ b/docs/ci-cd-environment/install-self-hosted-agent.md
@@ -28,7 +28,7 @@ cd /opt/semaphore/agent
 **2. Download the agent:**
 
 ```bash
-curl -L https://github.com/semaphoreci/agent/releases/download/v2.2.16/agent_Linux_x86_64.tar.gz -o agent.tar.gz
+curl -L https://github.com/semaphoreci/agent/releases/download/v2.2.21/agent_Linux_x86_64.tar.gz -o agent.tar.gz
 tar -xf agent.tar.gz
 ```
 
@@ -63,7 +63,7 @@ cd /opt/semaphore/agent
 **2. Download the agent:**
 
 ```bash
-curl -L https://github.com/semaphoreci/agent/releases/download/v2.2.16/agent_Linux_x86_64.tar.gz -o agent.tar.gz
+curl -L https://github.com/semaphoreci/agent/releases/download/v2.2.21/agent_Linux_x86_64.tar.gz -o agent.tar.gz
 tar -xf agent.tar.gz
 ```
 
@@ -110,7 +110,7 @@ cd /opt/semaphore/agent
 **2. Download the agent:**
 
 ```bash
-curl -L https://github.com/semaphoreci/agent/releases/download/v2.2.16/agent_Darwin_x86_64.tar.gz -o agent.tar.gz
+curl -L https://github.com/semaphoreci/agent/releases/download/v2.2.21/agent_Darwin_x86_64.tar.gz -o agent.tar.gz
 tar -xf agent.tar.gz
 ```
 
@@ -175,7 +175,7 @@ Set-Location C:\semaphore-agent
 **2. Download the agent:**
 
 ```
-Invoke-WebRequest "https://github.com/semaphoreci/agent/releases/download/v2.2.16/agent_Windows_x86_64.tar.gz" -OutFile agent.tar.gz
+Invoke-WebRequest "https://github.com/semaphoreci/agent/releases/download/v2.2.21/agent_Windows_x86_64.tar.gz" -OutFile agent.tar.gz
 tar.exe xvf agent.tar.gz
 ```
 
@@ -185,6 +185,37 @@ tar.exe xvf agent.tar.gz
 $env:SemaphoreEndpoint = "<your-organization>.semaphoreci.com"
 $env:SemaphoreRegistrationToken = "<your-agent-type-registration-token>"
 .\install.ps1
+```
+
+## Installing the agent on FIPS enabled RHEL
+
+The [Semaphore agent][agent repo] is written in Go, which does not provide FIPS friendly cryptography libraries. Due to that, the agent must be compiled from source using the [go-toolset][RHEL go-toolset] to be run on a FIPS enabled RHEL host.
+
+**1. Verify the host has FIPS mode enabled:**
+
+```bash
+sudo fips-mode-setup --check
+```
+
+**2. Install the [go-toolset][RHEL go-toolset]:**
+
+```bash
+sudo yum install go-toolset
+```
+
+**3. Download agent source and compile it from source:**
+
+```bash
+curl -L https://github.com/semaphoreci/agent/archive/refs/tags/v2.2.21.tar.gz -o agent.tar.gz
+tar -xf agent.tar.gz
+cd agent
+go build -ldflags='-s -w -X "main.VERSION=v2.2.21"' -o build/agent main.go
+```
+
+**4. Verify binary is FIPS compatible:**
+
+```bash
+go tool nm ./build/agent | grep FIPS
 ```
 
 ## Configure GitHub SSH keys
@@ -225,3 +256,4 @@ sudo chown $USER: /home/$USER/.ssh
 [agent repo]: https://github.com/semaphoreci/agent
 [checkout]: /reference/toolbox-reference/#checkout
 [GH meta API]: https://docs.github.com/en/rest/meta/meta#get-github-meta-information
+[RHEL go-toolset]: https://developers.redhat.com/blog/2019/06/24/go-and-fips-140-2-on-red-hat-enterprise-linux#using_go_toolset


### PR DESCRIPTION
Add instructions on how to run the Semaphore agent on a RHEL FIPS enabled host. Additionally, update agent and agent-aws-stack versions.