### PR TITLE
Change company name from RT to Semaphore

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 # Project information
 site_name: Semaphore 2.0 Documentation
 site_description: Semaphore 2.0 documentation
-site_author: Rendered Text
+site_author: Semaphore Technologies doo
 site_url: 'https://docs.semaphoreci.com'
 
 # Repository
@@ -9,7 +9,7 @@ repo_name: semaphoreci/docs
 repo_url: https://github.com/semaphoreci/docs
 
 # Copyright
-copyright: '&copy; 2009-2024 Rendered Text'
+copyright: '&copy; 2009-2024 Semaphore Technologies doo'
 
 theme:
   font:

--- a/unpublished/secrets_5b1700562c7d3a0fa9a2abd0.md
+++ b/unpublished/secrets_5b1700562c7d3a0fa9a2abd0.md
@@ -279,6 +279,6 @@ following:
     error: http status 504 received from upstream
 
 Generally speaking using the `-v` switch when things go wrong might help
-you or Rendered Text reveal the root of problem and correct it.
+you or Semaphore team reveal the root of problem and correct it.
 
 [1]: https://docs.semaphoreci.com/article/29-changing-organizations


### PR DESCRIPTION
Ticket: https://github.com/renderedtext/tasks/issues/6170
Changes all mentions of Rendered Text to Semaphore Technologies doo

what it does not do: 
does not change renderedtext [here](https://github.com/semaphoreci/docs/blob/master/docs/ci-cd-environment/kubernetes-support.md#adding-the-renderedtext-helm-repo) as helm charts stay with the old name. This might cause some confusion for people?