### PR TITLE
Updated FAQ to include newer information about exiting jobs

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -359,7 +359,10 @@ source ~/my_script
   <summary>Click for details</summary>
   <p>
 
-Using `exit` command closes the PTY and causes undefined behaviour for the command. As a workaround, you can use `return 0` or `echo "exit 0" | sh` instead.
+Using the `exit` command closes the PTY and causes the job to fail. If this isn't the desired behavior, you can use the `return 130` command with different `SEMAPHORE_JOB_RESULT` environmental variables to specify the desired behaviour:
+  - Stopped job: `return 130`
+  - Stopped job, but marked as successful: `export SEMAPHORE_JOB_RESULT=passed` then `return 130`
+  - Stopped job, but marked as failed: `export SEMAPHORE_JOB_RESULT=failed` then `return 130`
 
   </p>
 </details>


### PR DESCRIPTION
We have added options to exit a job gracefully, by setting environmental variables and using the 130 return code. I have updated the documentation to reflect that in the FAQ.