### PR TITLE
FAQ: Adding information about bash -e and similar

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -366,6 +366,7 @@ Using the <code>exit</code> command closes the PTY and causes the job to fail. I
 <br>- Stopped job, but marked as successful: <code>export SEMAPHORE_JOB_RESULT=passed</code> then <code>return 130</code>
 <br>- Stopped job, but marked as failed: <code>export SEMAPHORE_JOB_RESULT=failed</code> then <code>return 130</code>
 </p>
+Please note that some commands like <code>bash -e</code> or <code>set -x otrace</code> may override this behavior and make it not function correctly.
 
 </details>
 


### PR DESCRIPTION
Some commands change the behavior of this feature in Semaphore. We have received 2 tickets about this, and I believe we should add a small disclaimer to avoid this in the future.