### PR TITLE
Xcode14: Updating pages to add warnings about upcoming deprecation

### DIFF
--- a/docs/ci-cd-environment/macos-xcode-14-image.md
+++ b/docs/ci-cd-environment/macos-xcode-14-image.md
@@ -4,6 +4,8 @@ Description: The macos-xcode14 image is a customized image based on MacOS 12, wh
 
 # macOS Monterey Xcode 14 image
 
+> **WARNING: The macOS Xcode 14 OS image will be deprecated on September 30, 2024. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
+
 The `macos-xcode14` image is a customized image based on [MacOS 12.7][monterey-release-notes],
 which has been optimized for CI/CD. It comes with a set of preinstalled languages, databases,
 and utility tools commonly used for CI/CD workflows. The image can be paired

--- a/docs/programming-languages/swift.md
+++ b/docs/programming-languages/swift.md
@@ -17,6 +17,8 @@ Xcode, fastlane, CocoaPods, and all other tools is found below:
 * [macOS Xcode 14 Image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-14-image/)
 * [macOS Xcode 15 Image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/)
 
+> **WARNING: The macOS Xcode 14 OS image will be deprecated on September 30, 2024. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
+
 # Configuring continuous integration
 
 Below is a minimal `semaphore.yml` file, which starts an

--- a/docs/reference/pipeline-yaml-reference.md
+++ b/docs/reference/pipeline-yaml-reference.md
@@ -100,11 +100,14 @@ These are valid values for `os_image`:
 - `ubuntu2204` ([reference][ubuntu2204])
 - `macos-xcode15` ([reference][macos-xcode15])
 - `macos-xcode14` ([reference][macos-xcode14])
+- `macos-xcode16` ([reference][macos-xcode16])
+
+> **WARNING: The macOS Xcode 14 OS image will be deprecated on September 30, 2024. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
 
 The default operating system depends on the type of the machine:
 
 - For the `e1-standard-*` machine types, the default image is `ubuntu2004`
-- For the `a1-standard-*` machine types, the default image is `macos-xcode14`
+- For the `a1-standard-*` machine types, the default image is `macos-xcode15`
 
 ### Example of `os_image` usage
 
@@ -2182,6 +2185,7 @@ YAML parser, which is not a Semaphore 2.0 feature, rather the way YAML files fun
 [ubuntu2004]: https://docs.semaphoreci.com/ci-cd-environment/ubuntu-20.04-image/
 [ubuntu2204]: https://docs.semaphoreci.com/ci-cd-environment/ubuntu-22.04-image/
 [macos-xcode15]: https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/
+[macos-xcode16]: https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-16-image/
 [macos-xcode14]: https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-14-image/
 [conditions-reference]: https://docs.semaphoreci.com/reference/conditions-reference/
 [when-repo-skip-exemples]: https://github.com/renderedtext/when#skip-block-exection


### PR DESCRIPTION
I have updated several pages to include a warning that informs the users about the upcoming deprecation of xcode14, and urging them to upgrade to xcode15.

This also includes some misc. changes regarding our overall MacOS documentation.