### PR TITLE
Xcode14 full deprecation

### DIFF
--- a/docs/ci-cd-environment/macos-xcode-14-image.md
+++ b/docs/ci-cd-environment/macos-xcode-14-image.md
@@ -4,7 +4,7 @@ Description: The macos-xcode14 image is a customized image based on MacOS 12, wh
 
 # macOS Monterey Xcode 14 image
 
-> **WARNING: The macOS Xcode 14 OS image will be deprecated on September 30, 2024. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
+> **WARNING: The macOS Xcode 14 OS image is now deprecated. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
 
 The `macos-xcode14` image is a customized image based on [MacOS 12.7][monterey-release-notes],
 which has been optimized for CI/CD. It comes with a set of preinstalled languages, databases,

--- a/docs/examples/ios-continuous-integration-with-xcode.md
+++ b/docs/examples/ios-continuous-integration-with-xcode.md
@@ -12,6 +12,8 @@ React Native projects. Projects can be built with
 [Xcode 14][macos-xcode14] running on a macOS `a1-standard-4` 
 or higher [machine type][machine-types].
 
+> **WARNING: The macOS Xcode 14 OS image is now deprecated. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
+
 ## Example project
 
 Semaphore maintains an example iOS app written in Swift 5.1 with SwiftUI to

--- a/docs/programming-languages/swift.md
+++ b/docs/programming-languages/swift.md
@@ -10,19 +10,17 @@ React Native applications with customizable CI/CD workflows.
 If you’re new to Semaphore, we recommend reading our
 [guided tour](https://docs.semaphoreci.com/guided-tour/getting-started/) first.
 
-The macOS Xcode 14 and maxOS Xcode 15 images are available with a full complement of useful tools and 
+The macOS Xcode 15 and macOS Xcode 16 images are available with a full complement of useful tools and 
 utilities pre-installed. Information regarding the exact version numbers of macOS, 
 Xcode, fastlane, CocoaPods, and all other tools is found below:
 
-* [macOS Xcode 14 Image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-14-image/)
 * [macOS Xcode 15 Image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/)
-
-> **WARNING: The macOS Xcode 14 OS image will be deprecated on September 30, 2024. Please update to the newer [macOS Xcode 15](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) image.**
+* [macOS Xcode 16 Image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-16-image/)
 
 # Configuring continuous integration
 
 Below is a minimal `semaphore.yml` file, which starts an
-[Xcode 14 image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-14-image/) 
+[Xcode 15 image](https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/) 
 and runs `xcodebuild`:
 
 ``` yaml
@@ -31,7 +29,7 @@ name: Semaphore iOS Swift example
 agent:
   machine:
     type: a1-standard-4
-    os_image: macos-xcode14
+    os_image: macos-xcode15
 blocks:
   - name: Build
     task:
@@ -48,6 +46,6 @@ Semaphore maintains an [example project](https://github.com/semaphoreci-demos/se
 [full tutorial showing how to configure an iOS project for CI with Semaphore](https://docs.semaphoreci.com/examples/ios-continuous-integration-with-xcode/)
 is also available.
 
-[macos-xcode-14]: https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-14-image/
+[macos-xcode-15]: https://docs.semaphoreci.com/ci-cd-environment/macos-xcode-15-image/
 [example-project]: https://github.com/semaphoreci-demos/semaphore-demo-ios-swift-xcode
 [ios-tutorial]: https://docs.semaphoreci.com/examples/ios-continuous-integration-with-xcode/


### PR DESCRIPTION
We have now fully deprecated Xcode 14. This is an update to the documentation to reflect so.